### PR TITLE
fix: #159 - block attempts to place tags on AIR blocks

### DIFF
--- a/src/bukkit/bukkit-patch-adapter/src/main/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/adapter/PatchPlaceBreakBukkitAdapterApi.java
+++ b/src/bukkit/bukkit-patch-adapter/src/main/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/adapter/PatchPlaceBreakBukkitAdapterApi.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,6 +77,10 @@ public class PatchPlaceBreakBukkitAdapterApi {
    */
   public @NotNull CompletableFuture<Void> putTag(
       @NotNull org.bukkit.block.Block bukkitBlock, boolean isEphemeral) {
+    if (bukkitBlock.getType() == Material.AIR) {
+      return CompletableFuture.completedFuture(null);
+    }
+
     BlockLocation blockLocation = locationConverter.convert(bukkitBlock);
     return patchPlaceBreakApi.putTag(
         new Block(blockLocation, bukkitBlock.getType().name()), isEphemeral);
@@ -96,6 +101,7 @@ public class PatchPlaceBreakBukkitAdapterApi {
       @NotNull Collection<org.bukkit.block.Block> bukkitBlocks, @NotNull BlockFace blockFace) {
     Set<Block> blocks =
         bukkitBlocks.stream()
+            .filter(bukkitBlock -> bukkitBlock.getType() != Material.AIR)
             .map(
                 bukkitBlock ->
                     new Block(locationConverter.convert(bukkitBlock), bukkitBlock.getType().name()))
@@ -112,6 +118,10 @@ public class PatchPlaceBreakBukkitAdapterApi {
    * @see PatchPlaceBreakApi#removeTag(Block)
    */
   public @NotNull CompletableFuture<Void> removeTag(@NotNull org.bukkit.block.Block bukkitBlock) {
+    if (bukkitBlock.getType() == Material.AIR) {
+      return CompletableFuture.completedFuture(null);
+    }
+
     BlockLocation blockLocation = locationConverter.convert(bukkitBlock);
     return patchPlaceBreakApi.removeTag(new Block(blockLocation, bukkitBlock.getType().name()));
   }


### PR DESCRIPTION
## Describe your changes

Attempts were performed to place tags on AIR blocks whereas this is not relevant nor without issues (c.f. the linked issue)

## Issue ticket number and link

https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/issues/159
