### PR TITLE
fix: #163 - get rid of auto-reconcile by settling to only a warning message

### DIFF
--- a/src/bukkit/bukkit-plugin/src/main/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/ListenerRegister.java
+++ b/src/bukkit/bukkit-plugin/src/main/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/ListenerRegister.java
@@ -32,7 +32,6 @@ import fr.djaytan.minecraft.jobsreborn.patchplacebreak.bukkit.listener.jobs.Jobs
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
@@ -87,17 +86,5 @@ public class ListenerRegister {
     pluginManager.registerEvents(jobsExpGainListener, javaPlugin);
     pluginManager.registerEvents(jobsPrePaymentListener, javaPlugin);
     log.atInfo().log("Event listeners registered.");
-  }
-
-  public void reloadListeners() {
-    log.atInfo().log("Reloading event listeners...");
-    unregisterListeners();
-    registerListeners();
-    log.atInfo().log("Event listeners reloaded successfully.");
-  }
-
-  private void unregisterListeners() {
-    HandlerList.unregisterAll(javaPlugin);
-    log.atInfo().log("Event listeners unregistered.");
   }
 }

--- a/src/bukkit/bukkit-plugin/src/test/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/ListenerRegisterTest.java
+++ b/src/bukkit/bukkit-plugin/src/test/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/ListenerRegisterTest.java
@@ -44,12 +44,10 @@ import fr.djaytan.minecraft.jobsreborn.patchplacebreak.bukkit.listener.jobs.Jobs
 import fr.djaytan.minecraft.jobsreborn.patchplacebreak.bukkit.plugin.JobsRebornPatchPlaceBreakPlugin;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Provider;
 import org.awaitility.Awaitility;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,9 +74,7 @@ class ListenerRegisterTest {
 
   @BeforeEach
   void beforeEach() {
-    ListenerRegisterProvider listenerRegisterProvider = new ListenerRegisterProvider();
-    PatchPlaceBreakVerifier patchPlaceBreakVerifier =
-        new PatchPlaceBreakVerifier(listenerRegisterProvider, patchApi);
+    PatchPlaceBreakVerifier patchPlaceBreakVerifier = new PatchPlaceBreakVerifier(patchApi);
 
     BlockBreakListener blockBreakListener = new BlockBreakListener(patchApi);
     BlockGrowListener blockGrowListener = new BlockGrowListener(patchApi);
@@ -100,8 +96,6 @@ class ListenerRegisterTest {
             blockSpreadListener,
             jobsExpGainListener,
             jobsPrePaymentListener);
-
-    listenerRegisterProvider.setListenerRegister(listenerRegister);
   }
 
   @AfterAll
@@ -127,41 +121,5 @@ class ListenerRegisterTest {
 
     assertThat(isBlockBroken).isTrue();
     await().until(() -> patchApi.isPlaceAndBreakExploit(actionInfo, blockMock));
-  }
-
-  @Test
-  @DisplayName("When reloading listeners")
-  void whenReloadingListeners() {
-    // Given
-    WorldMock worldMock = serverMock.addSimpleWorld("world");
-    Location location = new Location(worldMock, 47, 64, -87);
-    BlockMock blockMock = new BlockMock(Material.STONE, location);
-    PlayerMock playerMock = serverMock.addPlayer();
-
-    // When
-    listenerRegister.reloadListeners();
-    boolean isBlockBroken = playerMock.simulateBlockBreak(blockMock);
-
-    // Then
-    ActionInfo actionInfo = new BlockActionInfo(blockMock, ActionType.BREAK);
-
-    assertThat(isBlockBroken).isTrue();
-    await().until(() -> patchApi.isPlaceAndBreakExploit(actionInfo, blockMock));
-  }
-
-  /* Helpers */
-
-  static class ListenerRegisterProvider implements Provider<ListenerRegister> {
-
-    private ListenerRegister listenerRegister;
-
-    @Override
-    public ListenerRegister get() {
-      return listenerRegister;
-    }
-
-    public void setListenerRegister(@NotNull ListenerRegister listenerRegister) {
-      this.listenerRegister = listenerRegister;
-    }
   }
 }

--- a/src/bukkit/bukkit-plugin/src/test/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/PatchPlaceBreakVerifierTest.java
+++ b/src/bukkit/bukkit-plugin/src/test/java/fr/djaytan/minecraft/jobsreborn/patchplacebreak/bukkit/listener/PatchPlaceBreakVerifierTest.java
@@ -22,7 +22,6 @@
  */
 package fr.djaytan.minecraft.jobsreborn.patchplacebreak.bukkit.listener;
 
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
@@ -78,7 +77,7 @@ class PatchPlaceBreakVerifierTest {
 
   @BeforeEach
   void beforeEach() {
-    patchPlaceBreakVerifier = new PatchPlaceBreakVerifier(() -> listenerRegister, patchApi);
+    patchPlaceBreakVerifier = new PatchPlaceBreakVerifier(patchApi);
   }
 
   @AfterAll
@@ -144,7 +143,7 @@ class PatchPlaceBreakVerifierTest {
     patchPlaceBreakVerifier.checkAndAttemptFixListenersIfRequired(environmentState).join();
 
     // Then
-    verify(listenerRegister).reloadListeners();
+    // A warning must be logged
   }
 
   /* Helpers */


### PR DESCRIPTION
## Describe your changes

Automatic reconcile is not trivial and costly to implement (because of asynchronous mode) without guarantees of success in the end, hence only sending warning message.

## Issue ticket number and link

#163 
