### PR TITLE
test: remove usages of JUnit internal Preconditions class

### DIFF
--- a/src/patch-place-break-core/pom.xml
+++ b/src/patch-place-break-core/pom.xml
@@ -153,11 +153,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-commons</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/storage/sql/access/SqlTagRepositoryIntegrationTest.java
+++ b/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/storage/sql/access/SqlTagRepositoryIntegrationTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.Preconditions;
 import org.testcontainers.containers.MySQLContainer;
 
 class SqlTagRepositoryIntegrationTest {
@@ -87,10 +86,6 @@ class SqlTagRepositoryIntegrationTest {
     @Test
     void whenNoOneAlreadyExist_shouldThenBeRetrievable() {
       // Given
-      Preconditions.condition(
-          sqlTagRepository.findByLocation(randomBlockLocation).isEmpty(),
-          String.format("No tag must exist at the following location: %s", randomBlockLocation));
-
       Tag tag = new Tag(randomBlockLocation, true, LocalDateTime.now());
 
       // When
@@ -136,10 +131,6 @@ class SqlTagRepositoryIntegrationTest {
           new BlockLocation(
               oldLocation.worldName(), oldLocation.x() + 1, oldLocation.y(), oldLocation.z());
 
-      Preconditions.condition(
-          sqlTagRepository.findByLocation(newLocation).isEmpty(),
-          String.format("No tag must exist at the following location: %s", newLocation));
-
       sqlTagRepository.put(oldTag);
 
       OldNewBlockLocationPairSet oldNewBlockLocationPairSet =
@@ -164,13 +155,6 @@ class SqlTagRepositoryIntegrationTest {
       BlockLocation newLocation =
           new BlockLocation(
               oldLocation.worldName(), oldLocation.x() + 1, oldLocation.y(), oldLocation.z());
-
-      Preconditions.condition(
-          sqlTagRepository.findByLocation(oldLocation).isEmpty(),
-          String.format("No tag must exist at the following location: %s", oldLocation));
-      Preconditions.condition(
-          sqlTagRepository.findByLocation(newLocation).isEmpty(),
-          String.format("No tag must exist at the following location: %s", newLocation));
 
       OldNewBlockLocationPairSet oldNewBlockLocationPairSet =
           new OldNewBlockLocationPairSet(

--- a/src/spigot-plugin/pom.xml
+++ b/src/spigot-plugin/pom.xml
@@ -137,11 +137,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-commons</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threeten-extra</artifactId>
       <scope>test</scope>

--- a/src/spigot-plugin/src/test/java/fr/djaytan/mc/jrppb/spigot/listener/ListenerRegisterTest.java
+++ b/src/spigot-plugin/src/test/java/fr/djaytan/mc/jrppb/spigot/listener/ListenerRegisterTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.Preconditions;
 
 class ListenerRegisterTest {
 
@@ -109,10 +108,6 @@ class ListenerRegisterTest {
     BlockMock blockMock = new BlockMock(Material.STONE, location);
     PlayerMock playerMock = serverMock.addPlayer();
     ActionInfo actionInfo = new BlockActionInfo(blockMock, ActionType.PLACE);
-
-    Preconditions.condition(
-        !patchApi.isPlaceAndBreakExploit(actionInfo, blockMock),
-        "No tag is supposed to exist yet on the targeted block");
 
     // When
     listenerRegister.registerListeners();

--- a/src/spigot-plugin/src/test/java/fr/djaytan/mc/jrppb/spigot/plugin/JobsRebornPatchPlaceBreakPluginTest.java
+++ b/src/spigot-plugin/src/test/java/fr/djaytan/mc/jrppb/spigot/plugin/JobsRebornPatchPlaceBreakPluginTest.java
@@ -47,7 +47,6 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.Preconditions;
 import org.threeten.extra.MutableClock;
 
 class JobsRebornPatchPlaceBreakPluginTest {
@@ -79,11 +78,7 @@ class JobsRebornPatchPlaceBreakPluginTest {
     WorldMock worldMock = serverMock.addSimpleWorld("world");
     Location nominalLocation = new Location(worldMock, 112.1, 64, 45.87);
     BlockMock blockToPlace = new BlockMock(Material.DIAMOND_ORE, nominalLocation);
-
     ActionInfo actionInfo = new BlockActionInfo(blockToPlace, ActionType.BREAK);
-    Preconditions.condition(
-        !patchApi.isPlaceAndBreakExploit(actionInfo, blockToPlace),
-        "No tag is supposed to exist yet on the targeted block");
 
     BlockPlaceEvent blockPlaceEvent =
         new BlockPlaceEvent(blockToPlace, null, null, null, playerMock, true, EquipmentSlot.HAND);
@@ -132,11 +127,7 @@ class JobsRebornPatchPlaceBreakPluginTest {
     WorldMock worldMock = serverMock.addSimpleWorld("world");
     Location nominalLocation = new Location(worldMock, 5869.25, 72, 457.01);
     BlockMock airBlockToBreak = new BlockMock(Material.AIR, nominalLocation);
-
     ActionInfo actionInfo = new BlockActionInfo(airBlockToBreak, ActionType.BREAK);
-    Preconditions.condition(
-        !patchApi.isPlaceAndBreakExploit(actionInfo, airBlockToBreak),
-        "No tag is supposed to exist yet on the targeted block");
 
     BlockBreakEvent blockBreakEvent = new BlockBreakEvent(airBlockToBreak, null);
 
@@ -160,11 +151,7 @@ class JobsRebornPatchPlaceBreakPluginTest {
     WorldMock worldMock = serverMock.addSimpleWorld("world");
     Location nominalLocation = new Location(worldMock, 5414.6, 74.5, 449.1);
     BlockMock waterBlockToBreak = new BlockMock(Material.WATER, nominalLocation);
-
     ActionInfo actionInfo = new BlockActionInfo(waterBlockToBreak, ActionType.BREAK);
-    Preconditions.condition(
-        !patchApi.isPlaceAndBreakExploit(actionInfo, waterBlockToBreak),
-        "No tag is supposed to exist yet on the targeted block");
 
     BlockBreakEvent blockBreakEvent = new BlockBreakEvent(waterBlockToBreak, null);
 


### PR DESCRIPTION
And we accept the risk of not meeting preconditions since:
* It is statistically impossible because of RNG implementation
* The impact is low since tests are generally executed multiple times (in localdev, in PRs and finally in main branch)