### PR TITLE
refactor: migrate partially to JPMS modules

### DIFF
--- a/src/commons-test/src/main/java/module-info.java
+++ b/src/commons-test/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * The MIT License
+ * Copyright © 2022 Loïc DUBOIS-TERMOZ (alias Djaytan)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+module commons.test {
+  requires org.apache.commons.lang3;
+  requires org.apache.commons.io;
+  requires org.jetbrains.annotations;
+}

--- a/src/patch-place-break-api/src/main/java/module-info.java
+++ b/src/patch-place-break-api/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ * Copyright © 2022 Loïc DUBOIS-TERMOZ (alias Djaytan)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+module jrppb.api {
+  requires org.jetbrains.annotations;
+
+  exports fr.djaytan.mc.jrppb.api;
+  exports fr.djaytan.mc.jrppb.api.entities;
+  exports fr.djaytan.mc.jrppb.api.properties;
+}

--- a/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/PatchPlaceBreakImpl.java
+++ b/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/PatchPlaceBreakImpl.java
@@ -53,7 +53,7 @@ public class PatchPlaceBreakImpl implements PatchPlaceBreakApi {
   private final TagRepository tagRepository;
 
   @Inject
-  public PatchPlaceBreakImpl(
+  PatchPlaceBreakImpl(
       @NotNull BlocksFilter blocksFilter,
       @NotNull Clock clock,
       @NotNull RestrictedBlocksProperties restrictedBlocksProperties,

--- a/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/ConfigManager.java
+++ b/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/ConfigManager.java
@@ -55,7 +55,7 @@ final class ConfigManager {
   private final PropertiesValidator propertiesValidator;
 
   @Inject
-  public ConfigManager(
+  ConfigManager(
       @NotNull @Named("dataFolder") Path dataFolder,
       @NotNull ConfigSerializer configSerializer,
       @NotNull PropertiesValidator propertiesValidator) {

--- a/src/patch-place-break-core/src/main/java/module-info.java
+++ b/src/patch-place-break-core/src/main/java/module-info.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ * Copyright © 2022 Loïc DUBOIS-TERMOZ (alias Djaytan)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+module jrppb.core {
+  // Internal dependencies
+  requires jrppb.api;
+
+  // Third-party dependencies
+  requires com.google.guice;
+  requires com.zaxxer.hikari;
+  requires flyway.core;
+  requires jakarta.inject;
+  requires jakarta.validation;
+  requires java.sql;
+  requires org.apache.commons.lang3;
+  requires org.apache.commons.io;
+  requires org.jetbrains.annotations;
+  requires org.slf4j;
+  requires org.spongepowered.configurate;
+  requires org.spongepowered.configurate.hocon;
+
+  // Reflection for Guice
+  opens fr.djaytan.mc.jrppb.core to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.config to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.config.serialization to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.config.validation to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.inject to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.storage.sql to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.storage.sql.access to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.storage.sql.jdbc to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.storage.sql.provider to
+      com.google.guice;
+  opens fr.djaytan.mc.jrppb.core.storage.sql.serializer to
+      com.google.guice;
+
+  // Reflection for Flyway
+  opens db.migration.mysql;
+  opens db.migration.sqlite;
+
+  // Reflection for Configurate
+  opens fr.djaytan.mc.jrppb.core.config.properties;
+}


### PR DESCRIPTION
The blocking points are the following ones:
* The JobsReborn dependency doesn't have a valid module name, preventing the migration of Spigot related modules
* The maven-shade-plugin doesn't support JPMS modules (at least yet)

This means the JPMS modules are useful only at compile time for some modules and never at runtime. Anyway, that's anyway a great improvement!