### PR TITLE
build(sortpom): apply more lenient configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,25 +321,20 @@
         <artifactId>sortpom-maven-plugin</artifactId>
         <version>3.3.0</version>
         <configuration>
+          <!-- General properties -->
           <createBackupFile>false</createBackupFile>
           <encoding>${project.encoding}</encoding>
+
+          <!-- Formatting properties -->
           <expandEmptyElements>false</expandEmptyElements>
-          <ignoreLineSeparators>false</ignoreLineSeparators>
-          <indentBlankLines>false</indentBlankLines>
-          <indentSchemaLocation>false</indentSchemaLocation>
-          <keepBlankLines>true</keepBlankLines>
-          <keepTimestamp>false</keepTimestamp>
+          <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
           <lineSeparator>\n</lineSeparator>
           <nrOfIndentSpace>2</nrOfIndentSpace>
+          <ignoreLineSeparators>false</ignoreLineSeparators>
+
+          <!-- Sorting properties -->
           <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
-          <sortDependencies>scope,groupId,artifactId</sortDependencies>
-          <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
-          <sortExecutions>false</sortExecutions>
           <sortModules>true</sortModules>
-          <sortPlugins>groupId,artifactId</sortPlugins>
-          <sortProperties>false</sortProperties>
-          <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-          <verifyFail>stop</verifyFail>
         </configuration>
         <executions>
           <execution>
@@ -360,6 +355,7 @@
             <phase>validate</phase>
             <configuration>
               <skip>${format.check.skip}</skip>
+              <verifyFail>Stop</verifyFail>
             </configuration>
           </execution>
         </executions>

--- a/src/patch-place-break-cts/pom.xml
+++ b/src/patch-place-break-cts/pom.xml
@@ -56,7 +56,6 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>patch-place-break-core</artifactId>
-      <!-- TODO: rely on SPI so that scope can be set to "runtime" instead -->
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Will allow more flexibility at when sorting elements manually (dependencies, plugins, ...). For example, grouping related plugins together (e.g. surefire and failsafe).