### PR TITLE
ci(maven): rename Maven build job

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -65,7 +65,7 @@ jobs:
           key: sonar
           restore-keys: sonar
 
-      - name: SonarCloud Quality Scan
+      - name: Maven build & SonarCloud quality scan
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The previous name hid the build part of the job:  only the SonarCloud quality scan was mentioned which is confusing.