### PR TITLE
build(maven): generate back coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,8 +524,6 @@
                         <!-- jboss-logging shall use SLF4J as logger provider -->
                         <org.jboss.logging.provider>slf4j</org.jboss.logging.provider>
                     </systemPropertyVariables>
-                    <!-- Make JVM warning goes away when using Mockito: https://github.com/mockito/mockito/issues/3111 -->
-                    <argLine>-Xshare:off</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -536,8 +534,6 @@
                     <includes>
                         <include>**/*IntegrationTest.java</include>
                     </includes>
-                    <!-- Make JVM warning goes away when using Mockito: https://github.com/mockito/mockito/issues/3111 -->
-                    <argLine>-Xshare:off</argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -562,13 +558,13 @@
                     <execution>
                         <id>prepare-agent-for-integration-tests</id>
                         <goals>
-                            <goal>report</goal>
+                            <goal>prepare-agent-integration</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>report-unit-tests</id>
                         <goals>
-                            <goal>prepare-agent-integration</goal>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                     <execution>


### PR DESCRIPTION
But undo the fix for getting rid of the JVM warning about class data sharing.

A question has been asked on StackOverflow in order to find a solution with the community help: https://stackoverflow.com/questions/77512409/adding-xshareoff-jvm-arg-break-jacoco-maven-plugin-setup