### PR TITLE
build(maven): rely exclusively on one JaCoCo agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,27 +550,15 @@
                 <version>0.8.11</version>
                 <executions>
                     <execution>
-                        <id>prepare-agent-for-unit-tests</id>
+                        <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>prepare-agent-for-integration-tests</id>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report-unit-tests</id>
+                        <id>report</id>
                         <goals>
                             <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report-integration-tests</id>
-                        <goals>
-                            <goal>report-integration</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Thanks to https://blog.soebes.io/posts/2023/10/2023-10-26-maven-jacoco-configuration/.