### PR TITLE
build(maven): get rid of CDS warnings from tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.1</version>
                     <configuration>
+                        <argLine>@{argLine} -Xshare:off</argLine>
                         <parallel>all</parallel>
                         <systemPropertyVariables>
                             <!-- Required to redirect Hibernate Validator's logs to SLF4J -->
@@ -430,6 +431,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>3.2.1</version>
+                    <configuration>
+                        <argLine>@{argLine} -Xshare:off</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
The StackOverflow issue related to CDS: https://stackoverflow.com/q/54205486/10165346

The one related to an issue with JaCoCo when adding JVM args to surefire & failsafe plugins: https://stackoverflow.com/q/77512409/10165346