### PR TITLE
build(maven): enable Java compiler linter for most warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,13 @@
                         <release>${java.version}</release>
                         <failOnWarning>true</failOnWarning>
                         <showDeprecation>true</showDeprecation>
+                        <compilerArgs>
+                            <arg>-Xlint:all</arg>
+                            <arg>-Xlint:-exports</arg>
+                            <arg>-Xlint:-requires-automatic</arg>
+                            <arg>-Xlint:-requires-transitive-automatic</arg>
+                            <arg>-Xlint:-serial</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
The following warnings have been disabled:
* `exports`: Warns about the issues regarding module exports.
* `requires-automatic`: Warns developers about the use of automatic modules in requires clauses.
* `requires-transitive-automatic`: Warns about automatic modules in requires transitive.
* `serial`: Warns about the serializable classes that do not provide a serial version ID. Also warns about access to non-public members from a serializable element.

More details about the `-Xlint` argument available here: https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html

The `exports` ones should be disabled since I doubt setting `requires transitive` for Jetbrains annotations is really wanted. API consumers must have the choice to require or not Jetbrains annotations.

The `requires-automatic` and `requires-transitive-automatic` ones shall be ignored since we can't rely exclusively on named modules.

Finally, the `serial` ones are not relevant as part of this project since the code never relies on Java serialization mechanism (especially for exceptions).