### PR TITLE
refactor(jpms): rename modules to ensure they will be globally unique

### DIFF
--- a/src/commons-test/src/main/java/module-info.java
+++ b/src/commons-test/src/main/java/module-info.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-module commons.test {
+module fr.djaytan.mc.jrppb.commons.test {
   requires static org.jetbrains.annotations;
   requires org.apache.commons.lang3;
   requires org.apache.commons.io;

--- a/src/patch-place-break-api/src/main/java/module-info.java
+++ b/src/patch-place-break-api/src/main/java/module-info.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-module jrppb.api {
+module fr.djaytan.mc.jrppb.api {
   requires static org.jetbrains.annotations;
 
   exports fr.djaytan.mc.jrppb.api;

--- a/src/patch-place-break-core/src/main/java/module-info.java
+++ b/src/patch-place-break-core/src/main/java/module-info.java
@@ -20,9 +20,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-module jrppb.core {
+module fr.djaytan.mc.jrppb.core {
   // Internal dependencies
-  requires jrppb.api;
+  requires fr.djaytan.mc.jrppb.api;
 
   // General dependencies
   requires static org.jetbrains.annotations;


### PR DESCRIPTION
Following the reverse-domain-name pattern which is a recommended practice (like it is the case for packages).