### PR TITLE
ci: activate manual workflow triggering

### DIFF
--- a/.github/workflows/conventional-commits-check.yml
+++ b/.github/workflows/conventional-commits-check.yml
@@ -1,6 +1,7 @@
 name: Conventional Commits - Check
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,6 +1,7 @@
 name: Maven - CI
 
 on:
+  workflow_dispatch:
   push:
     # Re-execute the CI on default branch only for status while ensuring it remains stable in any circumstances
     branches:

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -1,6 +1,7 @@
 name: Release - Perform
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'
@@ -22,6 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          ref: main
           # PAT required for bypassing tag protection
           token: ${{ secrets.PUSH_TOKEN }}
 

--- a/.github/workflows/security-scan-codeql.yml
+++ b/.github/workflows/security-scan-codeql.yml
@@ -1,6 +1,7 @@
 name: Security scan - CodeQL
 
 on:
+  workflow_dispatch:
   push:
     # Re-execute the CI on default branch only for status while ensuring it remains stable in any circumstances
     branches:

--- a/.github/workflows/security-scan-scorecard.yml
+++ b/.github/workflows/security-scan-scorecard.yml
@@ -1,6 +1,7 @@
 name: Security Scan - Scorecard
 
 on:
+  workflow_dispatch:
   branch_protection_rule:
   push:
     branches:
@@ -25,6 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          ref: main
           persist-credentials: false
 
       - name: Perform Scorecard Analysis


### PR DESCRIPTION
Mainly for the two following situations:
* New workflow version testing (thanks to the possibility to use the workflow file from a given branch)
* Retrigger a failing job without force pushing commits (more convenient, especially when the failure is only temporary, e.g. CodeQL usage limit reached)