### PR TITLE
ci(github): no longer bypass tag protection at releasing time

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -28,6 +28,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            uploads.github.com:443
             repo.maven.apache.org:443
             jitpack.io:443
             repo.papermc.io:443
@@ -35,8 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          # PAT required for bypassing tag protection
-          token: ${{ secrets.PUSH_TOKEN }}
           # Required for tag existence check
           fetch-depth: 0
 
@@ -108,21 +107,7 @@ jobs:
 
           echo "The plugin file which is going to be uploaded is '${PLUGIN_FILE}'"
 
-          RELEASE_VERSION='${{ steps.version.outputs.prefixed }}'
-
-          if [[ -n "$(git tag -l "${RELEASE_VERSION}")" ]]; then
-            echo "The tag '${RELEASE_VERSION}' already exists"
-            echo 'Aborting...'
-            exit 1
-          fi
-
-          echo "The tag which is going to be created is '${RELEASE_VERSION}'"
-
-          git tag "${RELEASE_VERSION}"
-          git push origin refs/tags/"${RELEASE_VERSION}"
-
-          gh release create "${RELEASE_VERSION}" "${PLUGIN_FILE}" \
+          gh release create ${{ steps.version.outputs.prefixed }} "${PLUGIN_FILE}" \
             --title ${{ steps.version.outputs.prefixed }} \
             --notes-file ${{ steps.changelog.outputs.file }} \
-            --target ${{ github.ref }} \
-            --verify-tag
+            --target ${{ github.ref }}


### PR DESCRIPTION
A new ruleset named "Release tags" has been created instead of the initially created tag protection. This change allows tag creation without protection, which is acceptable since in the end that's the release creation which really matter. Since the tag creation action is no longer protected, we can get rid of the GitHub PAT "PUSH_TOKEN", leading in the end to a better security.