### PR TITLE
build(maven): rename `plugin.*` properties to `spigotName.*`

### DIFF
--- a/src/spigot-plugin/pom.xml
+++ b/src/spigot-plugin/pom.xml
@@ -40,8 +40,8 @@
     <properties>
         <package.root>${project.groupId}</package.root>
         <package.lib>${package.root}.lib</package.lib>
-        <plugin.name>JobsReborn-PatchPlaceBreak</plugin.name>
-        <plugin.finalName>${plugin.name}-${project.version}</plugin.finalName>
+        <spigotPlugin.name>JobsReborn-PatchPlaceBreak</spigotPlugin.name>
+        <spigotPlugin.finalName>${spigotPlugin.name}-${project.version}</spigotPlugin.finalName>
     </properties>
 
     <dependencies>
@@ -161,7 +161,7 @@
     </dependencies>
 
     <build>
-        <finalName>${plugin.finalName}</finalName>
+        <finalName>${spigotPlugin.finalName}</finalName>
         <resources>
             <resource>
                 <filtering>true</filtering>

--- a/src/spigot-plugin/src/main/resources/plugin.yml
+++ b/src/spigot-plugin/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: ${plugin.name}
+name: ${spigotPlugin.name}
 version: ${version}
 author: Djaytan
 api-version: 1.17


### PR DESCRIPTION
The `plugin.name` property is already used by Maven plugins and thus conflict when executing the command `mvn help:evaluate --projects :spigot-plugin --quiet -Dexpression=plugin.name -DforceStdout`. By executing it, we get `Apache Maven Help Plugin` instead of `JobsReborn-PatchPlaceBreak`.