### PR TITLE
ci(release): stick with semantic-release naming conventions for release branches

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -5,9 +5,9 @@ module.exports = {
 
   branches: [
     'main',
-    'release/v+([0-9])?(.{+([0-9]),x}).x',
     'next',
     'next-major',
+    '+([0-9])?(.{+([0-9]),x}).x',
     {name: 'beta', prerelease: true},
     {name: 'alpha', prerelease: true}
   ],


### PR DESCRIPTION
The encountered error is the following one:
```
[10:30:30 PM] [semantic-release] › ✘  ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).
This may occur if your repository does not have a release branch, such as master.
Your configuration for the problematic branches is [].
```

This means that the release branch pattern `release/v+([0-9])?(.{+([0-9]),x}).x` isn't recognised as maintenance one as described in the following documentation: https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches.
Seems like prefixes aren't supported, enforcing the choice of the value `+([0-9])?(.{+([0-9]),x}).x` for maintenance branches.