### PR TITLE
ci(release): move config file at the expected location

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -5,9 +5,9 @@ module.exports = {
 
   branches: [
     'main',
-    'release/v+([0-9])?(.{+([0-9]),x}).x',
     'next',
     'next-major',
+    'release/v+([0-9])?(.{+([0-9]),x}).x',
     {name: 'beta', prerelease: true},
     {name: 'alpha', prerelease: true}
   ],


### PR DESCRIPTION
The encountered error is the following one:
```
[10:30:30 PM] [semantic-release] › ✘  ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).
This may occur if your repository does not have a release branch, such as master.
Your configuration for the problematic branches is [].
```

It can be reproduced locally by executing the `semantic-release` command in the `.github/` folder. Since the CLI only search config file in the current working directory, and since the config file is located in the root folder and not in the `.github/` one, then the config file is not found. The CLI doesn't provide a way to configure the config file path, meaning that the fix to be done is one of the following:
* Moving the config file under the `.github/` (easiest and cleaner solution by far)
* Changing the working directory to be the root project folder, which would imply as consequences to adjust other things (i.e. moving the `package.json`, `package-lock.json`, `.npmrc` and `commitlint.config.js` files in the root folder and adapting the associated GitHub Actions workflows) The second option is not desirable since we want to keep the root folder as refined as possible. This is what make the first option ideal since it refine it even more.

Here is the outcome after implementing the fix:
```
loicd@DESKTOP-781OBR8 MINGW64 ~/IdeaProjects/mc-jobs-reborn-patch-place-break/.github (ci/fix-too-many-release-branches)
$ npx --no-install semantic-release --dry-run
[23:46:33] [semantic-release] » ℹ  Running semantic-release version 23.0.0
[23:46:33] [semantic-release] » ✔  Loaded plugin "verifyConditions" from "@semantic-release/changelog"
[23:46:33] [semantic-release] » ✔  Loaded plugin "verifyConditions" from "semantic-release-github-pullrequest"
[23:46:33] [semantic-release] » ✔  Loaded plugin "verifyConditions" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[23:46:33] [semantic-release] » ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[23:46:33] [semantic-release] » ✔  Loaded plugin "analyzeCommits" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "verifyRelease" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[23:46:33] [semantic-release] » ✔  Loaded plugin "generateNotes" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
[23:46:33] [semantic-release] » ✔  Loaded plugin "prepare" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "publish" from "semantic-release-github-pullrequest"
[23:46:33] [semantic-release] » ✔  Loaded plugin "publish" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "publish" from "@semantic-release/github"
[23:46:33] [semantic-release] » ✔  Loaded plugin "addChannel" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "addChannel" from "@semantic-release/github"
[23:46:33] [semantic-release] » ✔  Loaded plugin "success" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "success" from "@semantic-release/github"
[23:46:33] [semantic-release] » ✔  Loaded plugin "fail" from "@semantic-release/exec"
[23:46:33] [semantic-release] » ✔  Loaded plugin "fail" from "@semantic-release/github"
[23:46:52] [semantic-release] » ℹ  This test run was triggered on the branch ci/fix-too-many-release-branches, while semantic-release is configured to only publish from main, therefore a new version won’t be published.
```