### PR TITLE
ci(release): setup the GITHUB_TOKEN environment variable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Release
         id: release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         working-directory: .github/
         run: |
           npx --no-install semantic-release --ci
@@ -74,7 +76,6 @@ jobs:
       TAG_NAME: ${{ needs.release-perform.outputs.release-tag }}
       ASSETS_DIR: ${{ github.workspace }}/assets
       SIGNATURES_DIR: ${{ github.workspace }}/signatures
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Harden runner
@@ -107,12 +108,16 @@ jobs:
           echo "The provided tag name '${TAG_NAME}' is valid"
 
       - name: Download release assets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: gh release download "${TAG_NAME}" --dir "${ASSETS_DIR}"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
 
       - name: Sign blob files
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir --parents "${SIGNATURES_DIR}"
 
@@ -190,6 +195,8 @@ jobs:
           done
 
       - name: Upload signature assets in release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [[ -z "$(ls --almost-all "${SIGNATURES_DIR}" 2>/dev/null)" ]]; then
             echo 'No asset to be uploaded in the GitHub release'


### PR DESCRIPTION
The observed issue at releasing time is the following one:
```
[11:11:44 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
[11:11:44 PM] [semantic-release] › ✘  Failed step "verifyConditions" of plugin "@semantic-release/github"
[11:11:44 PM] [semantic-release] › ℹ  Start step "fail" of plugin "@semantic-release/exec"
[11:11:44 PM] [semantic-release] › ✔  Completed step "fail" of plugin "@semantic-release/exec"
[11:11:44 PM] [semantic-release] › ℹ  Start step "fail" of plugin "@semantic-release/github"
[11:11:44 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
[11:11:44 PM] [semantic-release] › ✘  Failed step "fail" of plugin "@semantic-release/github"
[11:11:44 PM] [semantic-release] › ✘  ENOGHTOKEN No GitHub token specified.
A GitHub personal token (https://github.com/semantic-release/github#readme/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment.

Please make sure to create a GitHub personal token (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment. The token must allow to push to the repository Djaytan/mc-jobs-reborn-patch-place-break.

[11:11:44 PM] [semantic-release] › ✘  ENOGHTOKEN No GitHub token specified.
A GitHub personal token (https://github.com/semantic-release/github#readme/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment.

Please make sure to create a GitHub personal token (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment. The token must allow to push to the repository Djaytan/mc-jobs-reborn-patch-place-break.

[11:11:44 PM] [semantic-release] › ✘  An error occurred while running semantic-release: AggregateError:
    SemanticReleaseError: No GitHub token specified.
        at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/get-error.js:19:10)
        at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:106:17)
        at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
        at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:110:11)
    at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
    at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
    at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
    at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  pluginName: 'semantic-release-github-pullrequest'
}
AggregateError:
    AggregateError:
        SemanticReleaseError: No GitHub token specified.
            at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/get-error.js:19:10)
            at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:106:17)
            at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
            at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
            at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
            at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
        at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:110:11)
        at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
        at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
    SemanticReleaseError: No GitHub token specified.
        at getError (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/lib/get-error.js:7:10)
        at verify (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/lib/verify.js:134:17)
        at verifyConditions (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/index.js:51:9)
        at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
    at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:55:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async pluginsConfigAccumulator.<computed> [as verifyConditions] (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/index.js:87:11)
    at async run (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/index.js:106:3)
    at async Module.default (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/index.js:278:22)
    at async default (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/cli.js:55:5) {
  errors: [
    AggregateError:
        SemanticReleaseError: No GitHub token specified.
            at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/get-error.js:19:10)
            at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:106:17)
            at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
            at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
            at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
            at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
            at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/lib/verify.js:110:11)
        at verifyConditions (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release-github-pullrequest/index.js:7:9)
        at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
      pluginName: 'semantic-release-github-pullrequest'
    },
    SemanticReleaseError: No GitHub token specified.
        at getError (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/lib/get-error.js:7:10)
        at verify (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/lib/verify.js:134:17)
        at verifyConditions (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/github/index.js:51:9)
        at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
      code: 'ENOGHTOKEN',
      details: 'A [GitHub personal token](https://github.com/semantic-release/github#readme/blob/master/README.md#github-authentication) must be created and set in the `GH_TOKEN` or `GITHUB_TOKEN` environment variable on your CI environment.\n' +
        '\n' +
        'Please make sure to create a [GitHub personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the `GH_TOKEN` or `GITHUB_TOKEN` environment variable on your CI environment. The token must allow to push to the repository Djaytan/mc-jobs-reborn-patch-place-break.',
      semanticRelease: true,
      pluginName: '@semantic-release/github'
    }
  ]
}
```
=> https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/actions/runs/7777421501/job/21205696506

Which means that the `GITHUB_TOKEN` environment variable isn't available when dispatching the `semantic-release` command through the CI.

Based on this observation, it has been realized that the `GITHUB_TOKEN` environment variable is not automatically created by GitHub as opposed to what is currently done for the rest of properties of the `github` context (https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). This is confirmed when checking the default environment variables documented here: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables (no GITHUB_TOKEN environment variable listed).

Thanks to this understanding, it appears obvious why the `semantic-release` CLI is returning an auth error message telling us that the `GITHUB_TOKEN` environment variable is undefined whereas it must be.

Thus, the fix is really simple: defining the `GITHUB_TOKEN` environment variable by retrieving the token from the `github` context (https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).

Since for security purposes it's better to never expose the access token for steps which don't require it (principal of least privileges), all the workflows have been reviewed and adapted to follow this best practice. In fact the changes have been made exclusively in the `release-sign` job of the release workflow: the environment variable is defined only when interacting with the `gh` CLI and when signing JAR file through the `cosign` CLI.