### PR TITLE
ci(release): simplify semantic-release config

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -36,8 +36,7 @@ module.exports = {
             {type: 'test', section: '✅ Tests'},
             {type: 'ci', section: '📦 Continuous Integration'},
             {type: 'docs', section: '📖 Documentation'}
-          ],
-          releaseCommitMessageFormat: 'docs(changelog): release {{currentTag}}',
+          ]
         }
       }
     ],


### PR DESCRIPTION
The `releaseCommitMessageFormat` property is useless in the context of the `@semantic-release/release-notes-generator` plugin. The role of the plugin is to generate release notes only. More concretely speaking, we can see the plugin's behavior as generating and storing a value in a variable which will then be reusable by the other plugins later. No commit will be created nor pushed. That's the role of the plugin `semantic-release-github-pullrequest` (https://github.com/asbiin/semantic-release-github-pullrequest) which will create a PR for the changes made to the `CONTRIBUTING.md` file by the plugin `@semantic-release/changelog` (https://github.com/semantic-release/changelog).

The README file of the plugin can be found here: https://github.com/semantic-release/release-notes-generator. The specific documentation regarding the `releaseCommitMessageFormat` property can be found here: https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.0.0/README.md#releasecommitmessageformat-string. If new with the `semantic-release` tool, this documentation will be useful: https://semantic-release.gitbook.io/semantic-release/.