### PR TITLE
ci(github): simplify signature verification logic

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,12 +158,6 @@ jobs:
           CERTIFICATE_IDENTITY: ${{ github.server_url }}/${{ github.workflow_ref }}
           CERTIFICATE_OIDC_ISSUER: https://token.actions.githubusercontent.com
         run: |
-          echo "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
-          echo "GITHUB_REF=${GITHUB_REF}"
-          echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
-          echo "GITHUB_SHA=${GITHUB_SHA}"
-          echo "GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME}"
-
           for ASSET_FILE in "${ASSETS_DIR}"/*; do
             ASSET_NAME="$(basename "${ASSET_FILE}")"
             ASSET_FILE_NAME="${ASSETS_DIR}/${ASSET_NAME}"
@@ -186,12 +180,7 @@ jobs:
               --signature="${SIGNATURES_DIR}/${SIG_FILE_NAME}" \
               --certificate="${SIGNATURES_DIR}/${CERT_FILE_NAME}" \
               --certificate-identity="${CERTIFICATE_IDENTITY}" \
-              --certificate-oidc-issuer="${CERTIFICATE_OIDC_ISSUER}" \
-              --certificate-github-workflow-name="${GITHUB_WORKFLOW}" \
-              --certificate-github-workflow-ref="${GITHUB_REF}" \
-              --certificate-github-workflow-repository="${GITHUB_REPOSITORY}" \
-              --certificate-github-workflow-sha="${GITHUB_SHA}" \
-              --certificate-github-workflow-trigger="${GITHUB_EVENT_NAME}"
+              --certificate-oidc-issuer="${CERTIFICATE_OIDC_ISSUER}"
           done
 
       - name: Upload signature assets in release


### PR DESCRIPTION
This change is useful for an incoming one which consist on extracting the signature and verification logic in a script file. The final goal is to make local testing easier and improve the overall readability.

Here, redundant verifications are removed. Checking the workflow, the branch ref and the repository are already covered by the value of the `CERTIFICATE_IDENTITY` environment variable. The value is always expected to be `https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/.github/workflows/release.yml@refs/heads/main`.

Realistically, we don't care about verifying which event triggered the signing process. The same apply for the commit SHA verification. Based on that, removing these specific verifications for simplifications purposes is better (i.e. the `--certificate-github-workflow-trigger` and `--certificate-github-workflow-sha` args respectively).