### PR TITLE
docs(readme): fix signature verification command

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -92,7 +92,7 @@ PLUGIN_VERSION=''
 cosign verify-blob "JobsReborn-PatchPlaceBreak-${PLUGIN_VERSION}.jar" \
   --signature="JobsReborn-PatchPlaceBreak-${PLUGIN_VERSION}.jar-keyless.sig" \
   --certificate="JobsReborn-PatchPlaceBreak-${PLUGIN_VERSION}.jar-keyless.pem" \
-  --certificate-identity=https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/.github/workflows/release-sign.yml@refs/heads/main \
+  --certificate-identity=https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/.github/workflows/release.yml@refs/heads/main \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```
 


### PR DESCRIPTION
The documentation is no longer up-to-date after having merged the two release workflows as part of the following PR: https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/pull/522.

This change aims to fix that by replacing the no longer existing workflow file `release-sign.yml` by new one `release.yml`.