### PR TITLE
ci(renovate): rework Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "configMigration": true,
   "extends": [
     "config:best-practices",
-    "config:semverAllMonthly"
+    "schedule:monthly",
+    ":maintainLockFilesWeekly",
+    "security:openssf-scorecard",
+    "workarounds:mavenCommonsAncientVersion",
+    ":enableVulnerabilityAlertsWithLabel(t:security)",
+    ":label(t:dependencies)",
+    ":semanticCommits",
+    ":semanticCommitType(build)"
   ],
-  "labels": ["t:dependencies"],
-  "vulnerabilityAlerts": {
-    "labels": ["t:security"]
-  },
-  "osvVulnerabilityAlerts": true,
-  "semanticCommits": "enabled",
-  "semanticCommitType": "build"
+  "configMigration": true,
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
Actually, Renovate create a big PR including updates for all dependencies as it is the case for this one: https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/pull/516. This behavior is due to the usage of the preset `config:semverAllMonthly` (https://docs.renovatebot.com/presets-config/#configsemverallmonthly).

This approach has pros and cons, but in the end it feels like it requires more efforts for updating the dependencies since the PR is not ready to be merged. That is in opposition with the default Renovate behavior which consist on opening a potentially ready to be merged PR per dependency update. This setting was initially set for experimentation purposes only, so that's not a big deal to rollback the change since personally I'm don't like it and prefer the default one. Furthermore, general default grouping logics are already applied thanks to the `config:recommended` preset (https://docs.renovatebot.com/presets-config/#configrecommended) which is included by the `config:best-practices` one (https://docs.renovatebot.com/presets-config/#configbest-practices).

With this change comes opportunities to adjust/rework some other settings as well.

Since Renovate can generate lots of noises, keeping the scheduling once per month is greatly appreciated. That's applied thanks to the `schedule:monthly` preset (https://docs.renovatebot.com/presets-schedule/#schedulemonthly).

By scrolling through the existing and recently added presets, the `security:openssf-scorecard` has been found and can add a great indicator about dependencies security and quality (https://docs.renovatebot.com/presets-security/#securityopenssf-scorecard).

Other useful ones have been found which are the `:maintainLockFilesWeekly` (https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly) and `workarounds:mavenCommonsAncientVersion` (https://docs.renovatebot.com/presets-workarounds/#workaroundsmavencommonsancientversion) presets.

Finally, the configuration has been simplified by relying on other existing presets available here: https://docs.renovatebot.com/presets-default/.