### PR TITLE
ci(renovate): force "build" type for Renovate's commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     ":enableVulnerabilityAlertsWithLabel(t:security)",
     ":label(t:dependencies)",
     ":semanticCommits",
-    ":semanticCommitType(build)"
+    ":semanticCommitTypeAll(build)"
   ],
   "configMigration": true,
   "osvVulnerabilityAlerts": true


### PR DESCRIPTION
The commits created and pushed by Renovate are not compliant with the commitlint rules, leading to failing PRs. An example: https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/pull/543.

The encountered error is the following one:
```
⧗   input: chore(deps): update actions/cache action to v4
✖   type must be one of [feat, fix, perf, revert, refactor, build, test, ci, docs] [type-enum]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```

The `chore` type is not supported as per the specific commitlint rules (cf. the .github/commitlint.config.js file). Thus, it's important to rely on another type, and the most adapted one is `build`.

That's being said, the right type was supposed to be used by Renovate at committing time thanks to the `:semanticCommitType(build)` preset. However, for unknown reasons it doesn't work and the usage of `:semanticCommitTypeAll(build)` instead seams to be the way to go as per the following documentation: https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-type.