### PR TITLE
fix(spigot-adapter): #570 - logs noises when performing unsupported job action types

### DIFF
--- a/src/spigot-patch-adapter/src/main/java/fr/djaytan/mc/jrppb/spigot/adapter/JobActionTypeSupportChecker.java
+++ b/src/spigot-patch-adapter/src/main/java/fr/djaytan/mc/jrppb/spigot/adapter/JobActionTypeSupportChecker.java
@@ -20,28 +20,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package fr.djaytan.mc.jrppb.spigot.adapter.converter;
-
-import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.getSupportedJobActionTypes;
-import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.isSupportedJobActionType;
+package fr.djaytan.mc.jrppb.spigot.adapter;
 
 import com.gamingmesh.jobs.container.ActionType;
 import fr.djaytan.mc.jrppb.api.entities.BlockActionType;
-import jakarta.inject.Singleton;
-import org.apache.commons.lang3.Validate;
+import java.util.Arrays;
+import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
 
-@Singleton
-public class ActionTypeConverter implements UnidirectionalConverter<ActionType, BlockActionType> {
+public final class JobActionTypeSupportChecker {
 
-  @Override
-  public @NotNull BlockActionType convert(@NotNull ActionType jobActionType) {
-    Validate.isTrue(
-        isSupportedJobActionType(jobActionType),
-        "Unsupported job action type '%s' specified. Only the following ones are supported: %s",
-        jobActionType,
-        getSupportedJobActionTypes());
+  private JobActionTypeSupportChecker() {
+    // Static class
+  }
 
-    return BlockActionType.valueOf(jobActionType.name());
+  public static boolean isSupportedJobActionType(@NotNull ActionType jobActionType) {
+    Collection<ActionType> supportedJobActionTypes = getSupportedJobActionTypes();
+    return supportedJobActionTypes.contains(jobActionType);
+  }
+
+  public static boolean isUnsupportedJobActionType(@NotNull ActionType jobActionType) {
+    Collection<ActionType> unsupportedJobActionTypes = getUnsupportedJobActionTypes();
+    return unsupportedJobActionTypes.contains(jobActionType);
+  }
+
+  public static @NotNull Collection<ActionType> getSupportedJobActionTypes() {
+    return Arrays.stream(BlockActionType.values())
+        .map(BlockActionType::name)
+        .map(ActionType::valueOf)
+        .toList();
+  }
+
+  public static @NotNull Collection<ActionType> getUnsupportedJobActionTypes() {
+    Collection<ActionType> supportedTypes = getSupportedJobActionTypes();
+    return Arrays.stream(ActionType.values())
+        .filter(actionType -> !supportedTypes.contains(actionType))
+        .toList();
   }
 }

--- a/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/JobActionTypeSupportCheckerTest.java
+++ b/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/JobActionTypeSupportCheckerTest.java
@@ -1,0 +1,141 @@
+/*
+ * The MIT License
+ * Copyright © 2022 Loïc DUBOIS-TERMOZ (alias Djaytan)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package fr.djaytan.mc.jrppb.spigot.adapter;
+
+import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.getSupportedJobActionTypes;
+import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.getUnsupportedJobActionTypes;
+import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.isSupportedJobActionType;
+import static fr.djaytan.mc.jrppb.spigot.adapter.JobActionTypeSupportChecker.isUnsupportedJobActionType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gamingmesh.jobs.container.ActionType;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class JobActionTypeSupportCheckerTest {
+
+  private static final Collection<ActionType> SUPPORTED_JOB_ACTION_TYPES =
+      List.of(ActionType.PLACE, ActionType.BREAK, ActionType.TNTBREAK);
+  private static final Collection<ActionType> UNSUPPORTED_JOB_ACTION_TYPES =
+      List.of(
+          ActionType.STRIPLOGS,
+          ActionType.KILL,
+          ActionType.MMKILL,
+          ActionType.FISH,
+          ActionType.CRAFT,
+          ActionType.VTRADE,
+          ActionType.SMELT,
+          ActionType.BREW,
+          ActionType.ENCHANT,
+          ActionType.REPAIR,
+          ActionType.BREED,
+          ActionType.TAME,
+          ActionType.DYE,
+          ActionType.SHEAR,
+          ActionType.MILK,
+          ActionType.EXPLORE,
+          ActionType.EAT,
+          ActionType.CUSTOMKILL,
+          ActionType.COLLECT,
+          ActionType.BAKE);
+
+  @Nested
+  @DisplayName("isSupportedJobActionType()")
+  class IsSupportedJobActionType {
+
+    @ParameterizedTest
+    @MethodSource
+    void whenJobActionTypeIsSupported_shallReturnTrue(ActionType actionType) {
+      assertThat(isSupportedJobActionType(actionType)).isTrue();
+    }
+
+    private static @NotNull Stream<Arguments> whenJobActionTypeIsSupported_shallReturnTrue() {
+      return SUPPORTED_JOB_ACTION_TYPES.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void whenJobActionTypeIsUnsupported_shallReturnFalse(ActionType actionType) {
+      assertThat(isSupportedJobActionType(actionType)).isFalse();
+    }
+
+    private static @NotNull Stream<Arguments> whenJobActionTypeIsUnsupported_shallReturnFalse() {
+      return UNSUPPORTED_JOB_ACTION_TYPES.stream().map(Arguments::of);
+    }
+  }
+
+  @Nested
+  @DisplayName("isUnsupportedJobActionType()")
+  class IsUnsupportedJobActionType {
+
+    @ParameterizedTest
+    @MethodSource
+    void whenJobActionTypeIsSupported_shallReturnFalse(ActionType actionType) {
+      assertThat(isUnsupportedJobActionType(actionType)).isFalse();
+    }
+
+    private static @NotNull Stream<Arguments> whenJobActionTypeIsSupported_shallReturnFalse() {
+      return SUPPORTED_JOB_ACTION_TYPES.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void whenJobActionTypeIsUnsupported_shallReturnTrue(ActionType actionType) {
+      assertThat(isUnsupportedJobActionType(actionType)).isTrue();
+    }
+
+    private static @NotNull Stream<Arguments> whenJobActionTypeIsUnsupported_shallReturnTrue() {
+      return UNSUPPORTED_JOB_ACTION_TYPES.stream().map(Arguments::of);
+    }
+  }
+
+  @Nested
+  @DisplayName("getSupportedJobActionTypes()")
+  class GetSupportedJobActionTypes {
+
+    @Test
+    void whenRetrievingSupportedJobActionTypes_shallReturnTheExpectedOnes() {
+      assertThat(getSupportedJobActionTypes())
+          .containsExactlyInAnyOrderElementsOf(SUPPORTED_JOB_ACTION_TYPES);
+    }
+  }
+
+  @Nested
+  @DisplayName("getUnsupportedJobActionTypes()")
+  class GetUnsupportedJobActionTypes {
+
+    @Test
+    void whenRetrievingUnsupportedJobActionTypes_shallReturnTheExpectedOnes() {
+      assertThat(getUnsupportedJobActionTypes())
+          .containsExactlyInAnyOrderElementsOf(UNSUPPORTED_JOB_ACTION_TYPES);
+    }
+  }
+}

--- a/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/converter/ActionTypeConverterTest.java
+++ b/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/converter/ActionTypeConverterTest.java
@@ -23,45 +23,76 @@
 package fr.djaytan.mc.jrppb.spigot.adapter.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.gamingmesh.jobs.container.ActionType;
 import fr.djaytan.mc.jrppb.api.entities.BlockActionType;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ActionTypeConverterTest {
 
   private final ActionTypeConverter actionTypeConverter = new ActionTypeConverter();
 
   @Nested
-  class WhenConverting {
+  @DisplayName("convert()")
+  class Convert {
 
-    @Test
-    void withValidActionType_shouldReturnCorrespondingBlockActionType() {
-      // Given
-      ActionType validActionType = ActionType.BREAK;
-
-      // When
-      BlockActionType blockActionType = actionTypeConverter.convert(validActionType);
-
-      // Then
-      assertThat(blockActionType).isEqualTo(BlockActionType.BREAK);
+    @ParameterizedTest
+    @MethodSource
+    void whenConvertingSupportedActionType_shallProcessSuccessfully(
+        @NotNull ActionType actionType, @NotNull BlockActionType expectedValue) {
+      assertThat(actionTypeConverter.convert(actionType)).isEqualTo(expectedValue);
     }
 
-    @Test
-    void withInvalidActionType_shouldThrowException() {
-      // Given
-      ActionType invalidActionType = ActionType.BREED;
+    private static @NotNull Stream<Arguments>
+        whenConvertingSupportedActionType_shallProcessSuccessfully() {
+      return Stream.of(
+          arguments(ActionType.PLACE, BlockActionType.PLACE),
+          arguments(ActionType.BREAK, BlockActionType.BREAK),
+          arguments(ActionType.TNTBREAK, BlockActionType.TNTBREAK));
+    }
 
-      // When
-      Exception exception = catchException(() -> actionTypeConverter.convert(invalidActionType));
-
-      // Then
-      assertThat(exception)
+    @ParameterizedTest
+    @MethodSource
+    void whenConvertingUnsupportedActionType_shallThrowException(@NotNull ActionType actionType) {
+      assertThatThrownBy(() -> actionTypeConverter.convert(actionType))
           .isExactlyInstanceOf(IllegalArgumentException.class)
           .hasMessage(
-              "Invalid job action type 'BREED' specified. Expecting one of the following: [BREAK, TNTBREAK, PLACE]");
+              String.format(
+                  "Unsupported job action type '%s' specified. Only the following ones are supported: [BREAK, TNTBREAK, PLACE]",
+                  actionType.name()));
+    }
+
+    private static @NotNull Stream<Arguments>
+        whenConvertingUnsupportedActionType_shallThrowException() {
+      return Stream.of(
+          arguments(ActionType.STRIPLOGS),
+          arguments(ActionType.KILL),
+          arguments(ActionType.MMKILL),
+          arguments(ActionType.FISH),
+          arguments(ActionType.CRAFT),
+          arguments(ActionType.VTRADE),
+          arguments(ActionType.SMELT),
+          arguments(ActionType.BREW),
+          arguments(ActionType.ENCHANT),
+          arguments(ActionType.REPAIR),
+          arguments(ActionType.BREED),
+          arguments(ActionType.TAME),
+          arguments(ActionType.DYE),
+          arguments(ActionType.SHEAR),
+          arguments(ActionType.MILK),
+          arguments(ActionType.EXPLORE),
+          arguments(ActionType.EAT),
+          arguments(ActionType.CUSTOMKILL),
+          arguments(ActionType.COLLECT),
+          arguments(ActionType.BAKE));
     }
   }
 }


### PR DESCRIPTION
This bug was due to a missing check after receiving the JobsReborn event when listening pre-payments (cf. `fr.djaytan.mc.jrppb.spigot.listener.jobs.JobsPrePaymentListener` class).

In fact, the action type check was only performed when converting a JobsReborn `ActionType` to a JRPPB `BlockActionType` (cf. `ActionTypeConverter`). Detecting the invalid action type there is too late and thus lead to an exception stack trace being printed in the server logs. This bug is pretty serious since it can generate too much noises (it's easy to see the stack trace being printed several times under a second). Generating too much exception stack traces without real justification can be enough to encourage a user uninstalling the plugin.

This fix aims to perform the check sooner when checking place-and-break exploit so that it can be handled the right way. The "right way" means never considering unsupported job action types as exploit. For that, the place to implement it must belongs at the Spigot adapter level of the patch (i.e. the `spigot-patch-adapter` module). This is where the data extracted from the JobsReborn events are interpreted and thus where we will be able to check the job action type value (cf. `PatchPlaceBreakSpigotAdapterApi#isPlaceAndBreakExploit()`).

Since the job action type support check is now required at two different places (i.e. by the `PatchPlaceBreakSpigotAdapterApi` & `ActionTypeConverter` classes), then it's the opportunity to extract the associated methods into a dedicated class: `JobActionTypeSupportChecker`. The methods `getSupportedJobActionTypes()` and `getUnsupportedJobActionTypes()` have been made `public` since they can be considered as utilities in other parts of the production code or when writing tests (this is typically the case in the `ActionTypeConverter` & `PatchPlaceBreakSpigotAdapterApiBaseTest` classes).

We are no longer referring to "validating a job action type" but instead we "check if a job action type is supported". In fact, both names are nearly equivalent but the later is more accurate (what would it means to consider a job action type as "invalid"? Doesn't it mean that the action is unsupported by the patch? Having a "supported" or "unsupported" job action type sounds better and more explicit, especially since we know that not all actions types are supported by the patch: only the BREAK, TNTBREAK and PLACE ones are).

Improvements have been made in the test classes: tests related to a given production method (e.g. `isPlaceAndBreakExploit()` from the `PatchPlaceBreakSpigotAdapterApi` class) have been grouped together under an internal class so that it's easier to find them when updating the associated production method.

Closes #570