### PR TITLE
fix(release): specify the right root dir path when generating plugin

### DIFF
--- a/.github/scripts/generate-plugin.sh
+++ b/.github/scripts/generate-plugin.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 trap 'echo Error encountered while executing the script.' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-ROOT_REPOSITORY_DIR="${SCRIPT_DIR}/.."
+ROOT_REPOSITORY_DIR="${SCRIPT_DIR}/../.."
 
 NEW_VERSION="$1"
 DEV_VERSION='0.0.1-DEV-SNAPSHOT'


### PR DESCRIPTION
The error is not obvious especially when looking at the returned error message by the `semantic-release` CLI:

```
[3:57:06 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/exec"
[3:57:06 PM] [semantic-release] [@semantic-release/exec] › ℹ  Call script ./scripts/generate-plugin.sh 3.0.3
Generating plugin file for version 3.0.3...
Error encountered while executing the script.
[3:57:09 PM] [semantic-release] › ✘  Failed step "prepare" of plugin "@semantic-release/exec"
[3:57:09 PM] [semantic-release] › ✘  An error occurred while running semantic-release: Error: Command failed with exit code 1: ./scripts/generate-plugin.sh 3.0.3
Generating plugin file for version 3.0.3...
Error encountered while executing the script.
    at makeError (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/lib/exec.js:16:11)
    at async prepare (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/index.js:54:5)
    at async validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
    at async file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
    at async file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:32:5
    at async pluginsConfigAccumulator.<computed> [as prepare] (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/index.js:87:11)
    at async run (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/index.js:202:3) {
  shortMessage: 'Command failed with exit code 1: ./scripts/generate-plugin.sh 3.0.3',
  command: './scripts/generate-plugin.sh 3.0.3',
  escapedCommand: '"./scripts/generate-plugin.sh 3.0.3"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: 'Generating plugin file for version 3.0.3...\n' +
    'Error encountered while executing the script.',
  stderr: '',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false,
  pluginName: '@semantic-release/exec'
}
Error: Command failed with exit code 1: ./scripts/generate-plugin.sh 3.0.3
Generating plugin file for version 3.0.3...
Error encountered while executing the script.
    at makeError (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/lib/exec.js:16:11)
    at async prepare (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/index.js:54:5)
    at async validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
    at async file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
    at async file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:32:5
    at async pluginsConfigAccumulator.<computed> [as prepare] (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/index.js:87:11)
    at async run (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/index.js:202:3) {
  shortMessage: 'Command failed with exit code 1: ./scripts/generate-plugin.sh 3.0.3',
  command: './scripts/generate-plugin.sh 3.0.3',
  escapedCommand: '"./scripts/generate-plugin.sh 3.0.3"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: 'Generating plugin file for version 3.0.3...\n' +
    'Error encountered while executing the script.',
  stderr: '',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false,
  pluginName: '@semantic-release/exec'
}
```

We can see that the script has been executed, meaning that the file's permissions are well setup. We can see as well that the command `echo "Generating plugin file for version ${NEW_VERSION}..."` has been executed successfully as well. However, it seems the script stop its execution when reaching the `mvn` commands.

When checking the script content, we can observe that the `ROOT_REPOSITORY_DIR` is pointing to the wrong directory. Actually it resolves to the `.github` repository and not the project root one, meaning that the `mvn` command fails because no `pom.xml` file can be found in the current working directory. Based on that, the fix appears to be trivial.