### PR TITLE
ci(release): install Java 17 before releasing a new version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,12 @@ jobs:
           cache: npm
           cache-dependency-path: .github/package-lock.json
 
+      - name: Setup Java
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+        with:
+          java-version: 17
+          distribution: temurin
+
       - name: Install semantic-release
         working-directory: .github/
         run: npm clean-install


### PR DESCRIPTION
When executing the `generate-plugin.sh` script through the `semantic-release` CLI, the following error is encountered:

```
Caused by: org.codehaus.plexus.compiler.CompilerException: error: release version 17 not supported
```

And it makes sense since the Java version has not been setup, meaning that the fix is trivial.

This time, when setting up the `actions/setup-java` action, no cache is leveraged since it's useless and thus will use our cache quota for nothing. Only the version is set and that's it.