### PR TITLE
ci(release): get rid of broken semantic-release PR dependency

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -1,5 +1,3 @@
-const CHANGELOG_FILE = '.github/CHANGELOG.md';
-
 module.exports = {
   preset: 'conventionalcommits',
 
@@ -43,15 +41,7 @@ module.exports = {
     [
       '@semantic-release/changelog',
       {
-        changelogFile: CHANGELOG_FILE
-      }
-    ],
-    [
-      'semantic-release-github-pullrequest',
-      {
-        assets: [CHANGELOG_FILE],
-        pullrequestTitle: 'docs(changelog): release {{currentTag}}',
-        labels: ['t:release']
+        changelogFile: process.env.CHANGELOG_FILE
       }
     ],
     [

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
     outputs:
       release-tag: ${{ steps.release.outputs.tag }}
 
+    env:
+      CHANGELOG_FILE: ${{ github.workspace }}/docs/CHANGELOG.md
+
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -40,6 +43,15 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0 # Required by semantic-release
+
+      - name: Config Git user as release bot
+        env:
+          # https://github.com/orgs/community/discussions/26560#discussioncomment-3252339
+          RELEASE_BOT_NAME: 'github-actions[bot]'
+          RELEASE_BOT_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
+        run: |
+          git config --global user.name "${RELEASE_BOT_NAME}"
+          git config --global user.email "${RELEASE_BOT_EMAIL}"
 
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -66,6 +78,20 @@ jobs:
         run: |
           npx --no-install semantic-release --ci
           echo "tag=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create a PR for creating/updating the CHANGELOG file
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CHANGELOG_BRANCH_NAME: changelog/${{ steps.release.outputs.tag }}
+        run: |
+          git switch --create "${CHANGELOG_BRANCH_NAME}"
+          git commit --message='docs(changelog): release ${{ steps.release.outputs.tag }}' "${CHANGELOG_FILE}"
+          git push --set-upstream origin "${CHANGELOG_BRANCH_NAME}"
+
+          gh pr create --fill \
+            --label 't:release' \
+            --base ${{ github.ref_name }} \
+            --head "${CHANGELOG_BRANCH_NAME}"
 
   release-sign:
     name: Release - Sign


### PR DESCRIPTION
The semantic-release plugin "semantic-release-github-pullrequest" allowing the GitHub PR creation is broken (https://github.com/asbiin/semantic-release-github-pullrequest). The following PR need to be merged, but it seems like the repository is no longer actively maintained: https://github.com/asbiin/semantic-release-github-pullrequest/pull/148.

The motivation for maintaining a `CHANGELOG` file is well-explained here: https://github.com/asbiin/semantic-release-github-pullrequest/issues/40#issuecomment-1830972581.

So here comes this change aiming to replace this broken dependency. For that, we rely on the GitHub CLI for creating PRs (https://cli.github.com/manual/gh_pr_create).

Since it can be not trivial to clearly understand the `CHANGELOG` file generation, committing and pushing process, here is a summary:
1. The changelog file is generated/updated by the `@semantic-release/changelog` plugin when executing the `semantic-release` CLI. No Git action is performed by the plugin, meaning additional steps are required, hence the followings.
2. Create a branch from the current release one (e.g. "main") and switch on it since it will be used at PR creation time.
*NOTE: the `github.ref_name` context value point to the branch against which the workflow has been dispatched. While the "main" branch is considered as a release one, that's not the only one (cf. `branches` option from the `release.config.js` file). This means we must be able to ensure that the behavior will work in a generic way (e.g. creating a PR against the "alpha" release branch).*
4. Commit the changes made specifically to the `CHANGELOG` file
5. Push the changelog branch to the remote
6. Create a GitHub PR

The Git configuration has been adapted in order to state explicitly that the committer is a GitHub bot (i.e. the "[bot]" suffix in the name follow convention + is interpreted by the GitHub UI in the end). The current bot email has been selected so that a beautiful GitHub logo is displayed when checking the author associated to a given commit (e.g. https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/commit/30dd7ae22cf3ceb60d74806333cc6ce78c05f396) and when checking the contributors (https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/graphs/contributors). You can find explanation here: https://github.com/orgs/community/discussions/26560#discussioncomment-3252339.