### PR TITLE
ci(release): plugin JAR file nor the tag version name could not be found

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -48,7 +48,9 @@ module.exports = {
       '@semantic-release/exec',
       {
         prepareCmd: './scripts/generate-plugin.sh ${nextRelease.version}',
-        publishCmd: 'export TAG_NAME=${nextRelease.gitTag}'
+        publishCmd: 'echo "Printing tag version name in temporary file..." && '
+          + 'touch "${TMP_TAG_VERSION_NAME_FILE}" && '
+          + 'echo "${nextRelease.gitTag}" > ${TMP_TAG_VERSION_NAME_FILE}'
       }
     ],
     [
@@ -56,7 +58,7 @@ module.exports = {
       {
         assets: [
           {
-            path: 'src/spigot-plugin/target/JobsReborn-PatchPlaceBreak-${nextRelease.version}.jar',
+            path: '../src/spigot-plugin/target/JobsReborn-PatchPlaceBreak-*.*.*.jar',
             label: 'Spigot plugin for Minecraft servers'
           }
         ],

--- a/.github/scripts/generate-plugin.sh
+++ b/.github/scripts/generate-plugin.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 trap 'echo Error encountered while executing the script.' ERR
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-ROOT_REPOSITORY_DIR="${SCRIPT_DIR}/../.."
+ROOT_REPOSITORY_DIR="$(realpath "${SCRIPT_DIR}/../..")"
 
 NEW_VERSION="$1"
 DEV_VERSION='0.0.1-DEV-SNAPSHOT'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,10 +74,11 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TMP_TAG_VERSION_NAME_FILE: ${{ runner.temp }}/tag_version_name
         working-directory: .github/
         run: |
           npx --no-install semantic-release --ci
-          echo "tag=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "tag=$(cat "${TMP_TAG_VERSION_NAME_FILE}")" >> "${GITHUB_OUTPUT}"
 
       - name: Create a PR for creating/updating the CHANGELOG file
         env:


### PR DESCRIPTION
The release v3.0.3 has been published successfully (https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/releases/tag/v3.0.3)... But without the Spigot plugin nor the associated signature files! The PR for generating the changelog file failed to be created as well.

The observed errors:

```
[3:51:47 PM] [semantic-release] [@semantic-release/github] › ✘  The asset src/spigot-plugin/target/JobsReborn-PatchPlaceBreak-${nextRelease.version}.jar cannot be read, and will be ignored.
```

=> This means that the plugin path is wrong.

```
fatal: 'changelog/' is not a valid branch name
```

=> This means that the `${{ steps.release.outputs.tag }}` context resolution in `CHANGELOG_BRANCH_NAME: changelog/${{ steps.release.outputs.tag }}` is resolved as an empty string, leading to a branch name being `changelog/`.

The fix for the first issue consist on adjusting the path in two ways:
* Ensuring to start the search for the repository root directory
* Relying on glob pattern instead of Lodash template since the later isn't supported by the `@semantic-release/github` plugin for the `path` option specifically according to the documentation: https://github.com/semantic-release/github?tab=readme-ov-file#assets

```
The name and label for each assets are generated with Lodash template.
```

=> The `path` property isn't mentioned.

For the second issue, it seems clear that extracting the tag version name through environment variable isn't working. As a workaround, we just create a temporary file containing the value and then read it once the semantic-release CLI finishes its execution.