### PR TITLE
ci(release): apply workaround for resolving the envvar being interpreted as a Lodash template

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -49,8 +49,8 @@ module.exports = {
       {
         prepareCmd: './scripts/generate-plugin.sh ${nextRelease.version}',
         publishCmd: 'echo "Printing tag version name in temporary file..." && '
-          + 'touch "${TMP_TAG_VERSION_NAME_FILE}" && '
-          + 'echo "${nextRelease.gitTag}" > ${TMP_TAG_VERSION_NAME_FILE}'
+          + `touch '${process.env.TMP_TAG_VERSION_NAME_FILE}' && `
+          + `echo '$\{nextRelease.gitTag}' > '${process.env.TMP_TAG_VERSION_NAME_FILE}'`
       }
     ],
     [


### PR DESCRIPTION
Here is the observed error when dispatching the release workflow:

```
ReferenceError: TMP_TAG_VERSION_NAME_FILE is not defined
    at eval (lodash.templateSources[1]:9:10)
    at module.exports (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/lib/exec.js:7:39)
    at publish (/home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/@semantic-release/exec/index.js:62:26)
    at validator (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
    at file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
    at next (file:///home/runner/work/mc-jobs-reborn-patch-place-break/mc-jobs-reborn-patch-place-break/.github/node_modules/p-reduce/index.js:16:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
```

But in fact the issue is due to an attempt to resolve a Lodash template from the string `${TMP_TAG_VERSION_NAME_FILE}`. The hint is provided by the printed error stack trace: `at eval (lodash.templateSources[1]:9:10)`. Thus, we can implement a workaround by injecting the environment variable based on the `process.env` NodeJS variable content.