### PR TITLE
test: avoid usage of Given/When/Then structure for trivial tests

### DIFF
--- a/src/patch-place-break-api/src/test/java/fr/djaytan/mc/jrppb/api/entities/BlockLocationTest.java
+++ b/src/patch-place-break-api/src/test/java/fr/djaytan/mc/jrppb/api/entities/BlockLocationTest.java
@@ -62,39 +62,19 @@ class BlockLocationTest {
 
       @Test
       void andNominalValues_shouldMatchExpectedValues() {
-        // Given
-        Vector vector = new Vector(5, 0, -452);
-
-        // When
-        BlockLocation movedBlockLocation = BlockLocation.from(BLOCK_LOCATION, vector);
-
-        // Then
-        assertThat(movedBlockLocation).isEqualTo(new BlockLocation("world", -49, 67, 4420));
+        assertThat(BlockLocation.from(BLOCK_LOCATION, new Vector(5, 0, -452)))
+            .isEqualTo(new BlockLocation("world", -49, 67, 4420));
       }
 
       @Test
       void onOverflow_shouldMatchExpectedValues() {
-        // Given
-        Vector vector = new Vector(Integer.MAX_VALUE, 1, -1);
-
-        // When
-        BlockLocation movedBlockLocation = BlockLocation.from(BLOCK_LOCATION, vector);
-
-        // Then
-        assertThat(movedBlockLocation)
+        assertThat(BlockLocation.from(BLOCK_LOCATION, new Vector(Integer.MAX_VALUE, 1, -1)))
             .isEqualTo(new BlockLocation("world", Integer.MAX_VALUE - Math.abs(X), 68, 4871));
       }
 
       @Test
       void onUnderflow_shouldMatchExpectedValues() {
-        // Given
-        Vector vector = new Vector(10, -50, Integer.MIN_VALUE);
-
-        // When
-        BlockLocation movedBlockLocation = BlockLocation.from(BLOCK_LOCATION, vector);
-
-        // Then
-        assertThat(movedBlockLocation)
+        assertThat(BlockLocation.from(BLOCK_LOCATION, new Vector(10, -50, Integer.MIN_VALUE)))
             .isEqualTo(new BlockLocation("world", -44, 17, Integer.MIN_VALUE + Math.abs(Z)));
       }
     }

--- a/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/BlocksFilterTest.java
+++ b/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/BlocksFilterTest.java
@@ -60,13 +60,6 @@ class BlocksFilterTest {
 
   @Test
   void filterWithEmptyCollection() {
-    // Given
-    Set<Block> blocks = new HashSet<>();
-
-    // When
-    Set<Block> actualValue = blocksFilter.filter(blocks);
-
-    // Then
-    assertThat(actualValue).isEmpty();
+    assertThat(blocksFilter.filter(new HashSet<>())).isEmpty();
   }
 }

--- a/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/config/ConfigManagerTest.java
+++ b/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/config/ConfigManagerTest.java
@@ -23,6 +23,7 @@
 package fr.djaytan.mc.jrppb.core.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -258,16 +259,10 @@ class ConfigManagerTest {
 
     @Test
     void withoutExistingConfigFile_shouldThrowException() {
-      // Given
       String configFileName = "test.conf";
 
-      // When
-      Exception exception =
-          catchException(
-              () -> configManager.readAndValidate(configFileName, DataSourcePropertiesImpl.class));
-
-      // Then
-      assertThat(exception)
+      assertThatThrownBy(
+              () -> configManager.readAndValidate(configFileName, DataSourcePropertiesImpl.class))
           .isExactlyInstanceOf(IllegalStateException.class)
           .hasMessageStartingWith(
               "Failed to read config file 'test.conf'. Is the file absent or empty?");

--- a/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/config/validation/ConstraintViolationFormatterTest.java
+++ b/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/config/validation/ConstraintViolationFormatterTest.java
@@ -23,7 +23,7 @@
 package fr.djaytan.mc.jrppb.core.config.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import fr.djaytan.mc.jrppb.commons.test.TestResourcesHelper;
@@ -32,6 +32,7 @@ import jakarta.validation.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,15 +48,10 @@ class ConstraintViolationFormatterTest {
 
     @Test
     void withoutAnyConstraintViolation_shouldThrowException() {
-      // Given
-      Collection<ConstraintViolation<Object>> constraintViolations = Collections.emptySet();
+      var emptySet = new HashSet<ConstraintViolation<Object>>();
 
-      // When
-      Exception exception =
-          catchException(() -> ConstraintViolationFormatter.format(constraintViolations));
-
-      // Then
-      assertThat(exception).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThatThrownBy(() -> ConstraintViolationFormatter.format(emptySet))
+          .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/PatchPlaceBreakApiBaseTest.java
+++ b/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/PatchPlaceBreakApiBaseTest.java
@@ -72,14 +72,10 @@ abstract class PatchPlaceBreakApiBaseTest {
 
   @Test
   void whenTagDoesntExist_shouldNotDetectExploit() {
-    // Given
-    Block block = new Block(randomBlockLocation, "STONE");
-
-    // When
-    boolean isExploit = patchPlaceBreakApi.isPlaceAndBreakExploit(BlockActionType.BREAK, block);
-
-    // Then
-    assertThat(isExploit).isFalse();
+    assertThat(
+            patchPlaceBreakApi.isPlaceAndBreakExploit(
+                BlockActionType.BREAK, new Block(randomBlockLocation, "STONE")))
+        .isFalse();
   }
 
   @ParameterizedTest
@@ -94,9 +90,8 @@ abstract class PatchPlaceBreakApiBaseTest {
     mutableClock.add(timeElapsedAfterPut);
 
     // Then
-    boolean isExploit = patchPlaceBreakApi.isPlaceAndBreakExploit(BlockActionType.BREAK, block);
-
-    assertThat(isExploit).isEqualTo(isExploitExpected);
+    assertThat(patchPlaceBreakApi.isPlaceAndBreakExploit(BlockActionType.BREAK, block))
+        .isEqualTo(isExploitExpected);
   }
 
   private static @NotNull Stream<Arguments> whenPuttingTag() {

--- a/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/converter/LocationConverterTest.java
+++ b/src/spigot-patch-adapter/src/test/java/fr/djaytan/mc/jrppb/spigot/adapter/converter/LocationConverterTest.java
@@ -23,7 +23,7 @@
 package fr.djaytan.mc.jrppb.spigot.adapter.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import fr.djaytan.mc.jrppb.api.entities.BlockLocation;
@@ -74,14 +74,9 @@ class LocationConverterTest {
 
     @Test
     void fromLocationWithoutWorldValue_shouldThrowException(@Mock @NotNull Block block) {
-      // Given
       given(block.getWorld()).willReturn(null);
 
-      // When
-      Exception exception = catchException(() -> locationConverter.convert(block));
-
-      // Then
-      assertThat(exception)
+      assertThatThrownBy(() -> locationConverter.convert(block))
           .isExactlyInstanceOf(NullPointerException.class)
           .hasMessage("The associated world to a Bukkit block can't be null");
     }


### PR DESCRIPTION
The goal is to improve tests readability.