### PR TITLE
ci(github): specify minutes instead of seconds for timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-22.04
-    timeout-minutes: 300
+    timeout-minutes: 15
 
     permissions:
       contents: read
@@ -111,7 +111,7 @@ jobs:
   codeql-sast:
     name: CodeQL - Static Application Security Testing (SAST)
     runs-on: ubuntu-22.04
-    timeout-minutes: 300
+    timeout-minutes: 15
 
     permissions:
       actions: read

--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -14,7 +14,7 @@ jobs:
   scorecard-secure-supply-chain-analysis:
     name: Scorecard - Secure supply-chain analysis
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 5
 
     permissions:
       security-events: write # Required to upload found security gaps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   release-perform:
     name: Release - Perform
     runs-on: ubuntu-22.04
-    timeout-minutes: 300
+    timeout-minutes: 15
 
     permissions:
       contents: write # Required to publish a GitHub release
@@ -99,7 +99,7 @@ jobs:
   release-sign:
     name: Release - Sign
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 5
 
     needs: release-perform
 


### PR DESCRIPTION
A confusion was made when defining the jobs timeouts: seconds have been provided whereas minutes were expected...
No need to search far for understanding that: the property name contains the expected time unit: `timeout-minutes`.

This change aims to fix this confusion.

Additionally, the opportunity has been taken to review the current timeouts and adjust them if required. Most of the jobs execution duration remains under 5 minutes, but the timeout has been set to 15 minutes (three times higher) to tolerate rare/exceptional slowness (e.g. temporary service unavailability, overwhelming GitHub Actions runners, etc). The only exceptions are the release signing job and the Scorecard one since they are very fast to be executed (less than 1 minute in average).