### PR TITLE
docs: clean-up TODOs comments in code

### DIFF
--- a/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/serialization/ConfigSerializer.java
+++ b/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/serialization/ConfigSerializer.java
@@ -67,7 +67,6 @@ public final class ConfigSerializer {
     ConfigurationLoader<? extends ConfigurationNode> loader =
         ConfigLoaderFactory.createLoader(destConfigFile);
 
-    // TODO: really useful? And what about tests?
     if (!loader.canSave()) {
       throw new IllegalStateException(
           "The loader configuration is invalid and thus prevent processing serialization "
@@ -105,7 +104,6 @@ public final class ConfigSerializer {
     ConfigurationLoader<? extends ConfigurationNode> loader =
         ConfigLoaderFactory.createLoader(srcConfigFile);
 
-    // TODO: really useful? And what about tests?
     if (!loader.canLoad()) {
       throw new IllegalStateException(
           "The loader configuration is invalid and thus prevent processing deserialization "

--- a/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/validation/PropertiesValidator.java
+++ b/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/config/validation/PropertiesValidator.java
@@ -59,8 +59,7 @@ public final class PropertiesValidator {
 
     if (!constraintViolations.isEmpty()) {
       String formatted = ConstraintViolationFormatter.format(constraintViolations);
-      // TODO: normalize line separator (i.e. always use \n)
-      // TODO: weird to log an error + throw an exception: to be reworked
+
       LOG.atError().log("Detected constraint violations:{}{}", LINE_SEPARATOR, formatted);
       throw new IllegalStateException(
           String.format("Detected config constraint violations: %s", constraintViolations));

--- a/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/PatchPlaceBreakImplTest.java
+++ b/src/patch-place-break-core/src/test/java/fr/djaytan/mc/jrppb/core/PatchPlaceBreakImplTest.java
@@ -180,15 +180,6 @@ class PatchPlaceBreakImplTest {
      * consequences. For example, if later on a sugarcane grows and reaches this location where a
      * tag remains, then breaking this sugarcane will not provide any income to the player whereas
      * it is a legitimate Jobs action.
-     *
-     * <p>TODO: Associate to each tag a block type. Then, at PPB exploit check time, if the tag's
-     * block type doesn't match currently broken one (e.g. a sugarcane is broken whereas the tag
-     * initially apply to a stone block) then do not consider the action as an exploit one. This
-     * change will works only if the tags moving mechanism is flawless.
-     *
-     * <p>TODO: Review and eventually improve the tags moving behavior (does it works completely as
-     * intended, even for corner cases?). What about moving tags associated to air blocks (i.e.
-     * ephemeral tags and "ghost" ones?)
      */
     @Test
     void fromRestrictedBlock_shouldNotAttemptToRemoveAnyTag() {


### PR DESCRIPTION
Remove all the remaining TODOs comments from the code.

Most of them were wrong (e.g. we don't want to normalize line separator when logging) of very low value.

The ones regarding the safety checks and more advanced tests for tags moving scenarios have been converted as a GitHub issue: https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/issues/587.

The plan is to finish developments on this repository, hence this clean-up.