### PR TITLE
fix(core): fail on overflow/underflow

### DIFF
--- a/src/patch-place-break-api/src/main/java/fr/djaytan/mc/jrppb/api/entities/BlockLocation.java
+++ b/src/patch-place-break-api/src/main/java/fr/djaytan/mc/jrppb/api/entities/BlockLocation.java
@@ -43,9 +43,9 @@ public record BlockLocation(@NotNull String worldName, int x, int y, int z) {
    */
   public static @NotNull BlockLocation from(
       @NotNull BlockLocation blockLocation, @NotNull Vector direction) {
-    int newX = blockLocation.x() + direction.modX();
-    int newY = blockLocation.y() + direction.modY();
-    int newZ = blockLocation.z() + direction.modZ();
+    int newX = Math.addExact(blockLocation.x(), direction.modX());
+    int newY = Math.addExact(blockLocation.y(), direction.modY());
+    int newZ = Math.addExact(blockLocation.z(), direction.modZ());
     return new BlockLocation(blockLocation.worldName(), newX, newY, newZ);
   }
 }

--- a/src/patch-place-break-api/src/test/java/fr/djaytan/mc/jrppb/api/entities/BlockLocationTest.java
+++ b/src/patch-place-break-api/src/test/java/fr/djaytan/mc/jrppb/api/entities/BlockLocationTest.java
@@ -23,6 +23,7 @@
 package fr.djaytan.mc.jrppb.api.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.Nested;
@@ -50,13 +51,6 @@ class BlockLocationTest {
           () -> assertThat(blockLocation.z()).isEqualTo(Z));
     }
 
-    /**
-     * For now, the tests make in evidence a limitation of the current implementation since we can't
-     * scale indefinitely in cartesian coordinates as designed initially in Minecraft. In practice,
-     * there is no real impact since limitations will start to occur when reaching very high
-     * coordinates near to {@link Integer#MAX_VALUE}. Tho, it remains cleaner to fix that (maybe
-     * thanks to {@link java.math.BigInteger}?). An interesting problem to solve, in fact.
-     */
     @Nested
     class WithCopyConstructor {
 
@@ -75,27 +69,29 @@ class BlockLocationTest {
       @Test
       void onOverflow_shouldMatchExpectedValues() {
         // Given
-        Vector vector = new Vector(Integer.MAX_VALUE, 1, -1);
+        Vector vector = new Vector(0, 0, Integer.MAX_VALUE);
 
         // When
-        BlockLocation movedBlockLocation = BlockLocation.from(BLOCK_LOCATION, vector);
+        Exception exception = catchException(() -> BlockLocation.from(BLOCK_LOCATION, vector));
 
         // Then
-        assertThat(movedBlockLocation)
-            .isEqualTo(new BlockLocation("world", Integer.MAX_VALUE - Math.abs(X), 68, 4871));
+        assertThat(exception)
+            .isExactlyInstanceOf(ArithmeticException.class)
+            .hasMessage("integer overflow");
       }
 
       @Test
       void onUnderflow_shouldMatchExpectedValues() {
         // Given
-        Vector vector = new Vector(10, -50, Integer.MIN_VALUE);
+        Vector vector = new Vector(Integer.MIN_VALUE, 0, 0);
 
         // When
-        BlockLocation movedBlockLocation = BlockLocation.from(BLOCK_LOCATION, vector);
+        Exception exception = catchException(() -> BlockLocation.from(BLOCK_LOCATION, vector));
 
         // Then
-        assertThat(movedBlockLocation)
-            .isEqualTo(new BlockLocation("world", -44, 17, Integer.MIN_VALUE + Math.abs(Z)));
+        assertThat(exception)
+            .isExactlyInstanceOf(ArithmeticException.class)
+            .hasMessage("integer overflow");
       }
     }
   }


### PR DESCRIPTION
The possibility to encounter weird behaviors because of overflow/underflow was known. That being said, this was not a priority to fix since the likelihood of such exploitation is potentially impossible.

This change aims to fail when moving a tag from one block to another at worlds' limits in such way that an overflow or underflow occurs.