### PR TITLE
ci: allow 'chore' Conv. Commit type for dependencies updates & others

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -9,7 +9,8 @@ module.exports = {
 
     // Compliant with Angular conventions (getting rid of "style" and "chore" types)
     'type-enum': [2, 'always', [
-      'feat', 'fix', 'perf', 'revert', 'refactor', 'build', 'test', 'ci', 'docs'
+      'feat', 'fix', 'perf', 'revert', 'refactor', 'build', 'test', 'ci',
+      'docs', 'chore'
     ]],
 
     // Adjust some rules predefined by @commitlint/config-conventional

--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -12,7 +12,8 @@ module.exports = {
       {type: 'build', section: '🏗️ Build System'},
       {type: 'test', section: '✅ Tests'},
       {type: 'ci', section: '📦 Continuous Integration'},
-      {type: 'docs', section: '📖 Documentation'}
+      {type: 'docs', section: '📖 Documentation'},
+      {type: 'chore', section: '🧹 House Keeping'}
     ]
   },
   branches: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,6 @@
     ':enableVulnerabilityAlertsWithLabel(t:security)',
     ':label(t:dependencies)',
     ':semanticCommits',
-    ':semanticCommitType(build)'
   ],
   configMigration: true,
   osvVulnerabilityAlerts: true

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -163,7 +163,7 @@ from [Angular project](https://github.com/angular/angular/blob/main/CONTRIBUTING
   │       └─⫸ Commit Scope: core|spigot-adapter|spigot-plugin|readme|contributing|changelog|  
   │                          packaging|deps|other|github|renovate|release
   │
-  └─⫸ Commit Type: feat|fix|perf|refactor|docs|test|build|ci
+  └─⫸ Commit Type: feat|fix|perf|refactor|docs|test|build|ci|chore
 ```
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
@@ -181,6 +181,8 @@ It must be one of the following:
 * **build**: Changes that affect the build system or external dependencies (e.g. Spigot API, Guice,
   Flyway, ...)
 * **ci**: Changes to our CI configuration files and scripts (e.g. GitHub Actions, Renovate, ...)
+* **chore**: Changes that don't in any other category (e.g. dependencies' update, update
+  of `.gitignore` `.gitattributes` & `.editorconfig` files, ...)
 
 ##### Scope
 
@@ -204,9 +206,6 @@ But there are exceptions that shall be considered as well depending mostly on th
 
 * **packaging**: used for changes updating the Maven layout in all of our modules (e.g. groupId
   change, inherited plugins changes, ...)
-* **deps**: used for changes updating the project dependencies
-* **other**: used for changes affecting the following
-  files: `.gitignore` `.gitattributes` & `.editorconfig`
 
 ###### Specific to the `ci` type
 
@@ -214,6 +213,10 @@ But there are exceptions that shall be considered as well depending mostly on th
   file(s)
 * **renovate**: used for updating Renovate configuration
 * **release**: used for updating release-related configuration
+
+##### Specific to the `chore` & `fix` types
+
+* **deps**: used for changes updating the project dependencies
 
 ###### Special scope
 


### PR DESCRIPTION
This change is motivated by the fact the `:semanticCommitType(build)` doesn't work as intended: PRs with commits prefixed by `chore` are still created. However, the initial decision is now questioned.

The `chore` is a well-known conventional commit type and is especially used for some dependencies updates and when changing specific files like the `.gitignore` one.

Furthermore, the `config:recommended` Renovate's preset relies on this type by default for implementing a "smart" logic (in short, it chooses the `fix` type for non-tests Maven dependencies, `chore` otherwise).
=> https://docs.renovatebot.com/semantic-commits/

Based on that, reintegrating the `chore` type seems to be the way to go for sharing a standard setup with the OSS community and wider.