### PR TITLE
build(packaging): explicitly define the "test" scope for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
 
         <!-- ==================== Dependencies versions ==================== -->
         <version.flyway>10.7.2</version.flyway>
+        <version.junit>5.10.2</version.junit>
+        <version.mockito>5.10.0</version.mockito>
+        <version.testcontainers>1.19.5</version.testcontainers>
     </properties>
 
     <dependencyManagement>
@@ -224,55 +227,94 @@
 
             <!-- General test dependencies -->
             <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>3.25.3</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>5.10.0</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.mockito}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${version.mockito}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
                 <version>3.15.6</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.jparams</groupId>
                 <artifactId>to-string-verifier</artifactId>
                 <version>1.4.8</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threeten-extra</artifactId>
                 <version>1.7.2</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.jimfs</groupId>
                 <artifactId>jimfs</artifactId>
                 <version>1.3.0</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>4.2.0</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>1.19.5</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <artifactId>testcontainers</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>jdbc</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>mysql</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>mariadb</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Spigot-specific test dependencies -->
@@ -280,6 +322,7 @@
                 <groupId>com.github.seeseemelk</groupId>
                 <artifactId>MockBukkit-v1.17</artifactId>
                 <version>1.13.0</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Providing an explicit scope to the dependencies defined in the `dependencyManagement` section doesn't affect the Maven execution. However, it becomes a lot easier for Renovate to identify the test dependencies. Retrieving accurate information regarding the dependency type allows him to infer the Conventional Commit type to apply:

* If the dependency is a test one, then the prefix `chore` apply.
* If that's a dependency used at compile and/or runtime by the application, then the prefix `fix` apply.
* If that's a Maven plugin dependency, then the prefix `chore` apply.
* If the dependency is not defined in Maven (e.g. the ones defined in the `package.json` file for CI dependencies), then the prefix `chore` apply.

=> https://docs.renovatebot.com/semantic-commits/

When taking a look to the Renovate's Dependency Dashboard of this repository (https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/issues/6), we can see some mistakes:
* `equalsverifier` is a test dependency, but its prefix is `fix`
* Same for `testcontainers`

Hence this change for solving these two observable issues.

Since it's not possible to infer whether an `import` Maven scope is for test or production, it has been decided to abort usages of this scope for the test dependencies (i.e. JUnit, Mockito and Testcontainers). That's not ideal, but it's acceptable for improving the release note accuracy and correctness.