### PR TITLE
ci(github): fix OpenSSF scans by allowing communications with api.deps.dev host

### DIFF
--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -31,7 +31,8 @@ jobs:
             api.github.com:443
             api.osv.dev:443
             www.bestpractices.dev:443
-            api.securityscorecards.dev:443
+            api.deps.dev:443
+            repo.maven.apache.org:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443
             fulcio.sigstore.dev:443


### PR DESCRIPTION
Issue detected when merging the following change: https://github.com/Djaytan/mc-jobs-reborn-patch-place-break/commit/565f7241a62891fb5ba6775940e12dc68b8f3b43

https://app.stepsecurity.io/github/Djaytan/mc-jobs-reborn-patch-place-break/actions/runs/10533004919?jobid=29188255959&tab=network-events