### PR TITLE
fix(core): 639 - old database initialization was failing

### DIFF
--- a/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/storage/sql/provider/FlywayProvider.java
+++ b/src/patch-place-break-core/src/main/java/fr/djaytan/mc/jrppb/core/storage/sql/provider/FlywayProvider.java
@@ -36,11 +36,6 @@ import org.jetbrains.annotations.NotNull;
 @Singleton
 public final class FlywayProvider implements Provider<Flyway> {
 
-  private static final String DB_MIGRATION_DESCRIPTOR_FORMAT = "/db/migration/%s";
-  private static final String MIGRATION_HISTORY_TABLE_NAME =
-      "patch_place_break_flyway_schema_history";
-  private static final String PLACEHOLDER_PATCH_PLACE_BREAK_TABLE_NAME = "patchPlaceBreakTableName";
-
   private final ClassLoader classLoader;
   private final DataSource dataSource;
   private final DataSourceProperties dataSourceProperties;
@@ -57,16 +52,17 @@ public final class FlywayProvider implements Provider<Flyway> {
 
   public @NotNull Flyway get() {
     Map<String, String> placeholders = new HashMap<>();
-    placeholders.put(PLACEHOLDER_PATCH_PLACE_BREAK_TABLE_NAME, dataSourceProperties.getTable());
+    placeholders.put("patchPlaceBreakTableName", dataSourceProperties.getTable());
 
     return Flyway.configure(classLoader)
         .baselineOnMigrate(true)
+        .baselineVersion("3.0.0")
         .dataSource(dataSource)
         .failOnMissingLocations(true)
         .locations(getLocation())
         .loggers("slf4j")
         .placeholders(placeholders)
-        .table(MIGRATION_HISTORY_TABLE_NAME)
+        .table("patch_place_break_flyway_schema_history")
         .validateOnMigrate(false)
         .validateMigrationNaming(true)
         .load();
@@ -74,8 +70,7 @@ public final class FlywayProvider implements Provider<Flyway> {
 
   private @NotNull Location getLocation() {
     String descriptor =
-        String.format(
-            DB_MIGRATION_DESCRIPTOR_FORMAT, dataSourceProperties.getType().name().toLowerCase());
+        String.format("/db/migration/%s", dataSourceProperties.getType().name().toLowerCase());
     return new Location(descriptor);
   }
 }

--- a/src/patch-place-break-core/src/main/resources/db/migration/mysql/B3_0_0.sql
+++ b/src/patch-place-break-core/src/main/resources/db/migration/mysql/B3_0_0.sql
@@ -1,0 +1,13 @@
+-- NEVER MODIFY THIS FILE
+-- Flyway use checksum to detect accidental changes and fail if so
+
+CREATE TABLE ${patchPlaceBreakTableName}
+(
+  world_name           VARCHAR(128) NOT NULL,
+  location_x           INTEGER      NOT NULL,
+  location_y           INTEGER      NOT NULL,
+  location_z           INTEGER      NOT NULL,
+  is_ephemeral         INTEGER      NOT NULL,
+  created_at_timestamp VARCHAR(64)  NOT NULL,
+  PRIMARY KEY (world_name, location_x, location_y, location_z)
+);

--- a/src/patch-place-break-core/src/main/resources/db/migration/sqlite/B3_0_0.sql
+++ b/src/patch-place-break-core/src/main/resources/db/migration/sqlite/B3_0_0.sql
@@ -1,0 +1,13 @@
+-- NEVER MODIFY THIS FILE
+-- Flyway use checksum to detect accidental changes and fail if so
+
+CREATE TABLE ${patchPlaceBreakTableName}
+(
+  world_name           TEXT    NOT NULL,
+  location_x           INTEGER NOT NULL,
+  location_y           INTEGER NOT NULL,
+  location_z           INTEGER NOT NULL,
+  is_ephemeral         INTEGER NOT NULL,
+  created_at_timestamp TEXT    NOT NULL,
+  PRIMARY KEY (world_name, location_x, location_y, location_z)
+);

--- a/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/MariadbPatchPlaceBreakApiIT.java
+++ b/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/MariadbPatchPlaceBreakApiIT.java
@@ -49,6 +49,7 @@ class MariadbPatchPlaceBreakApiIT extends PatchPlaceBreakApiBaseTest {
   }
 
   @BeforeEach
+  @Override
   void beforeEach() throws IOException {
     int dbmsPort = MARIADB_CONTAINER.getMappedPort(DATABASE_ORIGINAL_PORT);
     String username = MARIADB_CONTAINER.getUsername();

--- a/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/OldMariadbPatchPlaceBreakApiIT.java
+++ b/src/patch-place-break-cts/src/test/java/fr/djaytan/mc/jrppb/cts/OldMariadbPatchPlaceBreakApiIT.java
@@ -28,33 +28,36 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.MariaDBContainer;
 
-class MysqlPatchPlaceBreakApiIT extends PatchPlaceBreakApiBaseTest {
+class OldMariadbPatchPlaceBreakApiIT extends PatchPlaceBreakApiBaseTest {
 
   private static final int DATABASE_ORIGINAL_PORT = 3306;
   private static final String DATABASE_NAME = "patch_place_break";
 
   @SuppressWarnings("resource") // Reusable containers feature enabled: do not clean-up containers!
-  private static final MySQLContainer<?> MYSQL_CONTAINER =
-      new MySQLContainer<>("mysql:8.1.0-oracle").withDatabaseName(DATABASE_NAME).withReuse(true);
+  private static final MariaDBContainer<?> MARIADB_CONTAINER =
+      new MariaDBContainer<>("mariadb:10.3.39-focal")
+          .withDatabaseName(DATABASE_NAME)
+          .withReuse(true);
 
   private static final String CONFIG_DATA_SOURCE_FILE_NAME = "dataSource.conf";
 
   @BeforeAll
   static void beforeAll() {
-    MYSQL_CONTAINER.start();
+    MARIADB_CONTAINER.start();
   }
 
   @BeforeEach
   @Override
   void beforeEach() throws IOException {
-    int dbmsPort = MYSQL_CONTAINER.getMappedPort(DATABASE_ORIGINAL_PORT);
-    String username = MYSQL_CONTAINER.getUsername();
-    String password = MYSQL_CONTAINER.getPassword();
+    int dbmsPort = MARIADB_CONTAINER.getMappedPort(DATABASE_ORIGINAL_PORT);
+    String username = MARIADB_CONTAINER.getUsername();
+    String password = MARIADB_CONTAINER.getPassword();
     String givenDataSourceConfFileContent =
         String.format(
-            TestResourcesHelper.getClassResourceAsString(this.getClass(), "mysql.conf", false),
+            TestResourcesHelper.getClassResourceAsString(
+                MariadbPatchPlaceBreakApiIT.class, "mariadb.conf", false),
             dbmsPort,
             username,
             password);


### PR DESCRIPTION
All details can be found in the associated GitHub issue.

In short: the column renaming SQL syntax `RENAME COLUMN ...` used in the `V3_0_0__Rename_initTimestamp_column.sql` Flyway migration script is not supported in old versions of MySQL/MariaDB databases (e.g. MariaDB 10.3/MySQL 5.5).

The solution has been to rely on the Flyway baseline migrations concept: https://documentation.red-gate.com/fd/baseline-migrations-184127465.html.

Opportunity has been taken to add some automated tests against an old database version in order to ensure wide compatibility.

Associated GitHub issue: #639.