### PR TITLE
ci(release): now rely on semantic-release default branches

### DIFF
--- a/.github/semantic-release/release.config.js
+++ b/.github/semantic-release/release.config.js
@@ -16,14 +16,6 @@ module.exports = {
       {type: 'chore', section: '🧹 House Keeping'}
     ]
   },
-  branches: [
-    'main',
-    'next',
-    'next-major',
-    'release/v+([0-9])?(.{+([0-9]),x}).x',
-    {name: 'beta', prerelease: true},
-    {name: 'alpha', prerelease: true}
-  ],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main, 'release/v*', next, next-major, beta, alpha]
+    branches: [main, '+.x', next, next-major, beta, alpha]
   pull_request:
-    branches: [main, 'release/v*', next, next-major, beta, alpha]
+    branches: [main, '+.x', next, next-major, beta, alpha]
   schedule:
     - cron: '5 4 * * *' # Every day at 04:05
 

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -3,9 +3,9 @@ name: Conventional Commit
 on:
   workflow_dispatch:
   push:
-    branches: [main, 'release/v*', next, next-major, beta, alpha]
+    branches: [main, '+.x', next, next-major, beta, alpha]
   pull_request:
-    branches: [main, 'release/v*', next, next-major, beta, alpha]
+    branches: [main, '+.x', next, next-major, beta, alpha]
 
 permissions: {}
 

--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   branch_protection_rule:
   push:
-    branches: [main, 'release/v*', next, next-major, beta, alpha]
+    branches: [main, '+.x', next, next-major, beta, alpha]
   schedule:
     - cron: '24 3 * * *' # At 03:24 every day
 


### PR DESCRIPTION
A newer version of semantic-release now include the `main` branch in the branches list now, hence this simplification opportunity.